### PR TITLE
feat(#30): branch-aware auto-resume, /session <TAB>, and empty session cleanup

### DIFF
--- a/doc/manual/en/03-quickstart.md
+++ b/doc/manual/en/03-quickstart.md
@@ -76,16 +76,18 @@ Then start with:
 /squash
 /delete feature/foo
 /sessions
-/session 550e8400-e29b-41d4-a716-446655440000
+/session <UUID>
 ```
 
 By default the tools operate on the current directory. Use `--workspace /path/to/project` to point **orangu** at another tree.
 
-**orangu** automatically resumes an existing session when you return to the same workspace and Git branch. When a previous session is found, the UUID is printed before the TUI starts:
+**orangu** automatically resumes an existing session when you return to the same workspace and Git branch. When a previous session is found, the status bar shows:
 
 ```text
 Resuming session 550e8400-e29b-41d4-a716-446655440000
 ```
+
+for five seconds or until the first command is run.
 
 On exit, the resume command is printed so you can return to the session from a different branch or machine:
 

--- a/doc/manual/en/03-quickstart.md
+++ b/doc/manual/en/03-quickstart.md
@@ -75,16 +75,26 @@ Then start with:
 /init_repo
 /squash
 /delete feature/foo
+/sessions
+/session 550e8400-e29b-41d4-a716-446655440000
 ```
 
 By default the tools operate on the current directory. Use `--workspace /path/to/project` to point **orangu** at another tree.
 
-Each run creates a session. When you exit, the resume command is printed:
+**orangu** automatically resumes an existing session when you return to the same workspace and Git branch. When a previous session is found, the UUID is printed before the TUI starts:
+
+```text
+Resuming session 550e8400-e29b-41d4-a716-446655440000
+```
+
+On exit, the resume command is printed so you can return to the session from a different branch or machine:
 
 ```text
 orangu --resume 550e8400-e29b-41d4-a716-446655440000
 ```
 
-Use `/sessions` to list previous sessions and find a UUID to resume.
+Sessions that had no LLM interaction on `main`, `master`, or outside a Git repository are deleted automatically on exit. Feature branch sessions are always kept.
+
+Use `/sessions` to list all sessions and their branches. Use `/session <uuid>` and Tab completion to find and print the resume command for a specific session.
 
 Lines whose first non-whitespace character is `#` stay local and are not sent to the model. Lines whose first non-whitespace character is `\` are ignored.

--- a/doc/manual/en/40-terminal.md
+++ b/doc/manual/en/40-terminal.md
@@ -48,13 +48,13 @@ Each run of `orangu` creates or resumes a session identified by a UUID.
 
 ### Automatic resume
 
-On startup, `orangu` checks whether a session already exists for the current workspace path and Git branch. If exactly one matching session with conversation history is found, it is resumed automatically:
+On startup, `orangu` checks whether a session already exists for the current workspace path and Git branch. If exactly one matching session with conversation history is found, it is resumed automatically. The status bar lower-left shows:
 
 ```text
 Resuming session 550e8400-e29b-41d4-a716-446655440000
 ```
 
-This message appears on the primary terminal before the TUI starts. No `--resume` flag is needed for normal branch-based workflows.
+for five seconds or until the first command is run. No `--resume` flag is needed for normal branch-based workflows.
 
 If more than one session matches the current workspace and branch, a fresh session is started instead. Use `--resume <uuid>` to target a specific session explicitly.
 
@@ -101,7 +101,7 @@ The `metadata` file records when the session was created, last used, which works
 }
 ```
 
-`branch` is `null` for sessions started outside a Git repository or in a detached HEAD state. Timestamps are Unix seconds (UTC).
+`branch` is an empty string for sessions started outside a Git repository or in a detached HEAD state. Timestamps are Unix seconds (UTC).
 
 ### Listing and switching sessions
 

--- a/doc/manual/en/40-terminal.md
+++ b/doc/manual/en/40-terminal.md
@@ -44,11 +44,41 @@ Press `Esc` twice within 2 seconds during the waiting state to cancel the active
 
 ## Sessions
 
-Each run of `orangu` creates a unique session identified by a UUID. When the client exits, the full resume command is printed so you can resume later:
+Each run of `orangu` creates or resumes a session identified by a UUID.
+
+### Automatic resume
+
+On startup, `orangu` checks whether a session already exists for the current workspace path and Git branch. If exactly one matching session with conversation history is found, it is resumed automatically:
+
+```text
+Resuming session 550e8400-e29b-41d4-a716-446655440000
+```
+
+This message appears on the primary terminal before the TUI starts. No `--resume` flag is needed for normal branch-based workflows.
+
+If more than one session matches the current workspace and branch, a fresh session is started instead. Use `--resume <uuid>` to target a specific session explicitly.
+
+### Manual resume
+
+To resume a specific session regardless of workspace or branch, pass `--resume <uuid>` when starting:
 
 ```text
 orangu --resume 550e8400-e29b-41d4-a716-446655440000
 ```
+
+This restores the previous conversation context and per-session readline history.
+
+### Session cleanup on exit
+
+When you exit, the resume command is printed:
+
+```text
+orangu --resume 550e8400-e29b-41d4-a716-446655440000
+```
+
+Sessions that had no LLM interaction (zero tokens generated) and are on `main`, `master`, or a workspace with no Git repository are deleted automatically on exit. No resume command is printed for deleted sessions. Sessions on feature branches are always kept even when empty, so that returning to the branch triggers auto-resume correctly.
+
+### Session storage
 
 Session data is stored under `~/.orangu/sessions/<uuid>/`:
 
@@ -60,32 +90,27 @@ metadata   session metadata (JSON)
 
 The `messages` file preserves the complete conversation so that resuming restores the exact context the model had when the session was last active.
 
-The `metadata` file is a JSON object with three fields:
+The `metadata` file records when the session was created, last used, which workspace it belongs to, and which Git branch was active:
 
 ```json
 {
   "started_at": 1748000000,
   "last_updated_at": 1748003600,
-  "workspace": "/home/user/myproject"
+  "workspace": "/home/user/myproject",
+  "branch": "feature/my-pr"
 }
 ```
 
-Timestamps are Unix seconds (UTC).
+`branch` is `null` for sessions started outside a Git repository or in a detached HEAD state. Timestamps are Unix seconds (UTC).
 
-To resume a previous session, pass `--resume <uuid>` when starting:
-
-```text
-orangu --resume 550e8400-e29b-41d4-a716-446655440000
-```
-
-This restores the previous conversation context and per-session readline history.
+### Listing and switching sessions
 
 Use `/sessions` to list all sessions:
 
 ```text
-UUID                                  STARTED       LAST          CMDS  WORKSPACE
-550e8400-e29b-41d4-a716-446655440000  202605220910  202605221143    42  /home/user/myproject
-a1b2c3d4-e5f6-7890-abcd-ef1234567890  202605210830  202605210831     3  /home/user/other
+UUID                                  STARTED       LAST          CMDS  BRANCH                WORKSPACE
+550e8400-e29b-41d4-a716-446655440000  202605220910  202605221143    42  feature/my-pr         /home/user/myproject
+a1b2c3d4-e5f6-7890-abcd-ef1234567890  202605210830  202605210831     3  -                     /home/user/other
 ```
 
 Pass an optional workspace filter to narrow results:
@@ -93,6 +118,20 @@ Pass an optional workspace filter to narrow results:
 ```text
 /sessions myproject
 ```
+
+Use `/session <uuid>` to print the resume command for a specific session:
+
+```text
+/session 550e8400-e29b-41d4-a716-446655440000
+```
+
+This outputs:
+
+```text
+orangu --resume 550e8400-e29b-41d4-a716-446655440000
+```
+
+Tab completion after `/session ` (with a trailing space) cycles through session UUIDs, newest first.
 
 ## History and navigation
 
@@ -141,6 +180,7 @@ All slash commands are handled locally. They are not sent to the model.
 | `/delete <branch>` | Delete a local branch |
 | `/open_file <path>` | Open a workspace file in $EDITOR |
 | `/sessions [workspace]` | List all sessions, optionally filtered by workspace path |
+| `/session [uuid]` | Print the resume command for a specific session; Tab completion cycles UUIDs newest-first |
 | `/usage` | Show usage statistics for this session |
 | `/build` | Build the workspace project (Rust, C, or Java) |
 | `/clear` | Clear the current conversation |
@@ -173,11 +213,12 @@ Free-form prompts are blocked when the server or model status in the header is r
 - `/init_repo` runs `git init` in the workspace directory; works both inside and outside an existing Git repository (reinitializing an existing repo is safe); `gh` has no equivalent so it always uses plain Git
 - `/squash` requires a Git repository; squashes all commits on the current branch (relative to `origin/main`, `origin/master`, `main`, or `master`, tried in that order) into a single commit using the oldest commit's message; `gh` has no equivalent so it always uses plain Git; squashing on `main` or `master` is blocked; requires at least two commits on the branch
 - `/delete <branch>` requires a Git repository and runs `git branch -D`; `gh` has no equivalent so it always uses plain Git; deleting `main` or `master` is blocked; Tab completion offers local branch names excluding `main` and `master`
-- `/sessions [workspace]` lists all sessions found under `~/.orangu/sessions/`; output is one line per session with aligned columns: UUID, start date, last-updated date, command count, and workspace path; sessions are sorted by creation time, most-recent first; an optional workspace argument filters the list to sessions whose workspace path contains the given string; each session directory also contains a `metadata` file (JSON) recording `started_at`, `last_updated_at`, and `workspace`
+- `/sessions [workspace]` lists all sessions found under `~/.orangu/sessions/`; output is one line per session with aligned columns: UUID, start date, last-updated date, command count, branch, and workspace path; sessions are sorted by creation time, most-recent first; an optional workspace argument filters the list to sessions whose workspace path contains the given string; the branch column shows `-` for sessions with no recorded branch
+- `/session [uuid]` prints the `orangu --resume <uuid>` command for the given session; Tab completion after `/session ` (with a trailing space) cycles through all session UUIDs, newest first; with no argument it lists all sessions (same as `/sessions`)
 - `/usage` shows session statistics: total application time, total time spent waiting for LLM responses, total tokens generated (counted with the bundled tokenizer), and average tokens per second
 - `/list_files` is a local convenience command and is separate from the model-facing `list_directory` tool
 - `/reload` also clears the current conversation history in memory
-- `/quit` exits immediately, while `Ctrl+C` uses a two-step confirmation; on exit the full resume command is printed
+- `/quit` exits immediately, while `Ctrl+C` uses a two-step confirmation; on exit the full resume command is printed unless the session had no LLM interaction and was on `main`, `master`, or outside a Git repository — in that case the session directory is deleted silently
 - Unknown slash commands are handled locally and produce an error message that points back to `/help`
 
 ## Natural-language command aliases
@@ -209,6 +250,7 @@ Local commands can also be entered in plain language. Examples:
 - `init` or `init repo` or `git init`
 - `delete feature/foo` or `delete branch feature/foo` or `git branch -D feature/foo`
 - `usage` or `show usage`
+- `session` or `switch session`
 
 Natural-language forms are recognized only for the built-in local command phrases. Ordinary prompts continue to go to the model.
 
@@ -258,11 +300,12 @@ The completion modes are checked in order:
 5. If the line starts with `/cherry_pick `, or with the natural-language prefixes `cherry pick `, `cherry-pick `, or `git cherry-pick `, complete abbreviated commit hashes from the default branch (`origin/main`, `origin/master`, `main`, or `master`, tried in that order).
 6. If the line starts with `/merge `, or with the natural-language prefixes `merge ` or `git merge `, complete local branch names first (from `git branch`), then remote-only branch names (from `git branch --all`).
 7. If the line starts with `/delete `, or with the natural-language prefixes `delete `, `delete branch `, or `git branch -D `, complete local branch names (from `git branch`) excluding `main` and `master`.
-8. If the line starts with `/model `, complete configured model profile names.
-9. If the line starts with `/open_file ` or `/show_file `, complete workspace file paths recursively for the first positional argument. `/show_file` also completes `--hash` and `--author`. When a file path is already present, the next Tab press cycles through that file's commit history (abbreviated hashes from `git log --follow`).
-10. If the line starts with the natural-language prefixes `open `, `open file `, `edit `, or `edit file `, complete workspace file paths recursively.
-11. If the line starts with `/`, complete built-in slash commands such as `/help`, `/list_models`, `/list_files`, `/show_file`, `/tools`, and `/quit`.
-12. Otherwise, complete filesystem entries from the current token relative to the workspace, using the token before the cursor.
+8. If the line starts with `/session ` (with a trailing space), complete session UUIDs sorted newest-first by last-modified time.
+9. If the line starts with `/model `, complete configured model profile names.
+10. If the line starts with `/open_file ` or `/show_file `, complete workspace file paths recursively for the first positional argument. `/show_file` also completes `--hash` and `--author`. When a file path is already present, the next Tab press cycles through that file's commit history (abbreviated hashes from `git log --follow`).
+11. If the line starts with the natural-language prefixes `open `, `open file `, `edit `, or `edit file `, complete workspace file paths recursively.
+12. If the line starts with `/`, complete built-in slash commands such as `/help`, `/list_models`, `/list_files`, `/show_file`, `/tools`, and `/quit`.
+13. Otherwise, complete filesystem entries from the current token relative to the workspace, using the token before the cursor.
 
 Path-completion details:
 

--- a/src/bin/orangu/commands.rs
+++ b/src/bin/orangu/commands.rs
@@ -139,6 +139,7 @@ pub enum LocalCommand<'a> {
     Squash,
     DeleteBranch(Option<Cow<'a, str>>),
     OpenFile(&'a str),
+    Session(Option<Cow<'a, str>>),
     Sessions(Option<Cow<'a, str>>),
     Usage,
     Build,
@@ -199,12 +200,21 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
         "/init_repo" => Some(LocalCommand::InitRepo),
         "/squash" => Some(LocalCommand::Squash),
         "/delete" => Some(LocalCommand::DeleteBranch(None)),
+        "/session" => Some(LocalCommand::Session(None)),
         "/sessions" => Some(LocalCommand::Sessions(None)),
         "/usage" => Some(LocalCommand::Usage),
         "/build" => Some(LocalCommand::Build),
         "/clear" => Some(LocalCommand::Clear),
         "/quit" => Some(LocalCommand::Quit),
         _ => {
+            if let Some(args) = input.strip_prefix("/session ") {
+                let uuid = args.trim();
+                return Some(LocalCommand::Session(if uuid.is_empty() {
+                    None
+                } else {
+                    Some(Cow::Borrowed(uuid))
+                }));
+            }
             if let Some(args) = input.strip_prefix("/sessions ") {
                 let workspace = args.trim();
                 return Some(LocalCommand::Sessions(if workspace.is_empty() {
@@ -579,6 +589,9 @@ pub fn parse_natural_language_command(input: &str) -> Option<LocalCommand<'_>> {
                 return Some(LocalCommand::DeleteBranch(Some(Cow::Borrowed(branch))));
             }
         }
+    }
+    if matches_ci(input, &["session", "switch session"]) {
+        return Some(LocalCommand::Session(None));
     }
     if matches_ci(input, &["sessions", "list sessions", "show sessions"]) {
         return Some(LocalCommand::Sessions(None));

--- a/src/bin/orangu/completion.rs
+++ b/src/bin/orangu/completion.rs
@@ -51,6 +51,7 @@ pub const COMMANDS: &[&str] = &[
     "/squash",
     "/delete",
     "/open_file",
+    "/session",
     "/sessions",
     "/usage",
     "/build",
@@ -167,6 +168,14 @@ pub fn completion_candidates(
             .filter(|b| !is_protected_branch(b) && b.starts_with(branch_prefix))
             .collect();
         return Some((start, cursor, branches));
+    }
+
+    if let Some(uuid_prefix) = prefix.strip_prefix("/session ") {
+        let candidates = session_uuids_newest_first()
+            .into_iter()
+            .filter(|u| u.starts_with(uuid_prefix))
+            .collect();
+        return Some(("/session ".len(), cursor, candidates));
     }
 
     if prefix.starts_with('/') {
@@ -712,6 +721,34 @@ pub fn open_file_completion_prefix(prefix: &str) -> Option<(usize, &str)> {
     }
 
     None
+}
+
+fn session_uuids_newest_first() -> Vec<String> {
+    let Some(home) = home::home_dir() else {
+        return Vec::new();
+    };
+    let sessions_dir = home.join(".orangu/sessions");
+    let Ok(entries) = std::fs::read_dir(&sessions_dir) else {
+        return Vec::new();
+    };
+    let mut dirs: Vec<(String, u64)> = entries
+        .flatten()
+        .filter(|e| e.path().is_dir())
+        .filter_map(|e| {
+            let name = e.file_name().to_str()?.to_string();
+            let mtime = e
+                .metadata()
+                .ok()?
+                .modified()
+                .ok()?
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            Some((name, mtime))
+        })
+        .collect();
+    dirs.sort_by_key(|e| std::cmp::Reverse(e.1));
+    dirs.into_iter().map(|(name, _)| name).collect()
 }
 
 pub fn natural_show_file_completion_prefix(prefix: &str) -> Option<(usize, &str)> {

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -35,7 +35,10 @@ use orangu::{
     llm::{ChatMessage, StreamMetrics, normalized_openai_endpoint},
     session::ChatSession,
     tools::ToolExecutor,
-    tui::{ScreenRenderArgs, StatusFragment, render_screen, render_thinking_status, render_working_status},
+    tui::{
+        ScreenRenderArgs, StatusFragment, render_screen, render_thinking_status,
+        render_working_status,
+    },
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -136,7 +139,10 @@ async fn run() -> Result<()> {
         Some(id) => (id.clone(), true),
         None => {
             let workspace_str = workspace.display().to_string();
-            match find_session_for_workspace_branch(&workspace_str, current_branch.as_deref().unwrap_or("")) {
+            match find_session_for_workspace_branch(
+                &workspace_str,
+                current_branch.as_deref().unwrap_or(""),
+            ) {
                 Some(existing_id) => (existing_id, true),
                 None => (Uuid::new_v4().to_string(), false),
             }
@@ -178,11 +184,12 @@ async fn run() -> Result<()> {
     let mut pending_commands = VecDeque::new();
     let mut usage_stats = UsageStats::new().with_session(&session_id);
     let mut history = load_history(&session_hist_path)?;
-    let mut startup_notice_until: Option<std::time::Instant> = if is_resumed && args.resume.is_none() {
-        Some(std::time::Instant::now() + std::time::Duration::from_secs(5))
-    } else {
-        None
-    };
+    let mut startup_notice_until: Option<std::time::Instant> =
+        if is_resumed && args.resume.is_none() {
+            Some(std::time::Instant::now() + std::time::Duration::from_secs(5))
+        } else {
+            None
+        };
     let status_http_client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
         .build()?;
@@ -384,7 +391,8 @@ async fn run() -> Result<()> {
     }
 
     drop(_terminal_ui_guard);
-    if usage_stats.total_tokens == 0 && is_ephemeral_branch(current_branch.as_deref().unwrap_or("")) {
+    if usage_stats.total_tokens == 0 && is_ephemeral_branch(current_branch.as_deref().unwrap_or(""))
+    {
         delete_session_dir(&session_dir);
     } else {
         eprintln!("orangu --resume {session_id}");
@@ -1314,7 +1322,13 @@ fn list_sessions_output(workspace_filter: Option<&str>) -> Result<String> {
             .unwrap_or_else(|| "-".to_string());
         let branch = meta
             .as_ref()
-            .map(|m| if m.branch.is_empty() { "-" } else { m.branch.as_str() })
+            .map(|m| {
+                if m.branch.is_empty() {
+                    "-"
+                } else {
+                    m.branch.as_str()
+                }
+            })
             .unwrap_or("-");
         let workspace = meta.as_ref().map(|m| m.workspace.as_str()).unwrap_or("-");
         lines.push(format!(

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -35,7 +35,7 @@ use orangu::{
     llm::{ChatMessage, StreamMetrics, normalized_openai_endpoint},
     session::ChatSession,
     tools::ToolExecutor,
-    tui::{ScreenRenderArgs, render_screen, render_thinking_status, render_working_status},
+    tui::{ScreenRenderArgs, StatusFragment, render_screen, render_thinking_status, render_working_status},
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -136,7 +136,7 @@ async fn run() -> Result<()> {
         Some(id) => (id.clone(), true),
         None => {
             let workspace_str = workspace.display().to_string();
-            match find_session_for_workspace_branch(&workspace_str, current_branch.as_deref()) {
+            match find_session_for_workspace_branch(&workspace_str, current_branch.as_deref().unwrap_or("")) {
                 Some(existing_id) => (existing_id, true),
                 None => (Uuid::new_v4().to_string(), false),
             }
@@ -160,11 +160,9 @@ async fn run() -> Result<()> {
                 started_at: current_unix_timestamp(),
                 last_updated_at: current_unix_timestamp(),
                 workspace: workspace.display().to_string(),
-                branch: current_branch.clone(),
+                branch: current_branch.clone().unwrap_or_default(),
             },
         )?;
-    } else if args.resume.is_none() {
-        eprintln!("Resuming session {session_id}");
     }
 
     if is_resumed {
@@ -180,6 +178,11 @@ async fn run() -> Result<()> {
     let mut pending_commands = VecDeque::new();
     let mut usage_stats = UsageStats::new().with_session(&session_id);
     let mut history = load_history(&session_hist_path)?;
+    let mut startup_notice_until: Option<std::time::Instant> = if is_resumed && args.resume.is_none() {
+        Some(std::time::Instant::now() + std::time::Duration::from_secs(5))
+    } else {
+        None
+    };
     let status_http_client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
         .build()?;
@@ -205,12 +208,15 @@ async fn run() -> Result<()> {
             prompt_branch: prompt_branch.as_deref(),
             header_status,
         };
+        let resume_left_status = startup_notice_until
+            .filter(|&deadline| std::time::Instant::now() < deadline)
+            .map(|_| StatusFragment::plain(format!("Resuming session {session_id}")));
         print_screen(
             render,
             ScreenState {
                 transcript: output_state.lines(),
                 scroll_offset: output_state.scroll_offset(),
-                left_status: None,
+                left_status: resume_left_status,
                 pending_count: pending_commands.len(),
                 pending_line: None,
                 input: input_state.as_str(),
@@ -261,6 +267,7 @@ async fn run() -> Result<()> {
 
         output_state.push_input(&format!("> {next_input}"));
         output_state.reset_scroll();
+        startup_notice_until = None;
         print_screen(
             render,
             ScreenState {
@@ -377,7 +384,7 @@ async fn run() -> Result<()> {
     }
 
     drop(_terminal_ui_guard);
-    if usage_stats.total_tokens == 0 && is_ephemeral_branch(current_branch.as_deref()) {
+    if usage_stats.total_tokens == 0 && is_ephemeral_branch(current_branch.as_deref().unwrap_or("")) {
         delete_session_dir(&session_dir);
     } else {
         eprintln!("orangu --resume {session_id}");
@@ -1107,7 +1114,7 @@ struct SessionMetadata {
     last_updated_at: u64,
     workspace: String,
     #[serde(default)]
-    branch: Option<String>,
+    branch: String,
 }
 
 fn current_unix_timestamp() -> u64 {
@@ -1191,7 +1198,7 @@ fn update_session_metadata_timestamp(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn find_session_for_workspace_branch(workspace: &str, branch: Option<&str>) -> Option<String> {
+fn find_session_for_workspace_branch(workspace: &str, branch: &str) -> Option<String> {
     let sessions_dir = home::home_dir()?.join(SESSIONS_DIRECTORY);
     if !sessions_dir.exists() {
         return None;
@@ -1215,7 +1222,7 @@ fn find_session_for_workspace_branch(workspace: &str, branch: Option<&str>) -> O
         if meta.workspace != workspace {
             continue;
         }
-        if meta.branch.as_deref() != branch {
+        if meta.branch != branch {
             continue;
         }
         let has_messages = path
@@ -1235,8 +1242,8 @@ fn find_session_for_workspace_branch(workspace: &str, branch: Option<&str>) -> O
     }
 }
 
-fn is_ephemeral_branch(branch: Option<&str>) -> bool {
-    matches!(branch, None | Some("main") | Some("master"))
+fn is_ephemeral_branch(branch: &str) -> bool {
+    matches!(branch, "" | "main" | "master")
 }
 
 fn delete_session_dir(session_dir: &Path) {
@@ -1307,7 +1314,7 @@ fn list_sessions_output(workspace_filter: Option<&str>) -> Result<String> {
             .unwrap_or_else(|| "-".to_string());
         let branch = meta
             .as_ref()
-            .and_then(|m| m.branch.as_deref())
+            .map(|m| if m.branch.is_empty() { "-" } else { m.branch.as_str() })
             .unwrap_or("-");
         let workspace = meta.as_ref().map(|m| m.workspace.as_str()).unwrap_or("-");
         lines.push(format!(

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -130,9 +130,17 @@ async fn run() -> Result<()> {
     ));
     let mut current_endpoint = Some(startup_endpoint.clone());
 
-    let session_id = match &args.resume {
-        Some(id) => id.clone(),
-        None => Uuid::new_v4().to_string(),
+    let current_branch = workspace_branch_name(&workspace);
+
+    let (session_id, is_resumed) = match &args.resume {
+        Some(id) => (id.clone(), true),
+        None => {
+            let workspace_str = workspace.display().to_string();
+            match find_session_for_workspace_branch(&workspace_str, current_branch.as_deref()) {
+                Some(existing_id) => (existing_id, true),
+                None => (Uuid::new_v4().to_string(), false),
+            }
+        }
     };
     let session_dir = session_dir_path(&session_id)?;
     std::fs::create_dir_all(&session_dir).with_context(|| {
@@ -145,18 +153,21 @@ async fn run() -> Result<()> {
     let session_messages_path = session_dir.join("messages");
     let session_metadata_path = session_dir.join("metadata");
 
-    if args.resume.is_none() {
+    if !is_resumed {
         save_session_metadata(
             &session_metadata_path,
             &SessionMetadata {
                 started_at: current_unix_timestamp(),
                 last_updated_at: current_unix_timestamp(),
                 workspace: workspace.display().to_string(),
+                branch: current_branch.clone(),
             },
         )?;
+    } else if args.resume.is_none() {
+        eprintln!("Resuming session {session_id}");
     }
 
-    if args.resume.is_some() {
+    if is_resumed {
         let messages = load_session_messages(&session_messages_path)?;
         session.restore(messages);
     }
@@ -366,7 +377,11 @@ async fn run() -> Result<()> {
     }
 
     drop(_terminal_ui_guard);
-    eprintln!("orangu --resume {session_id}");
+    if usage_stats.total_tokens == 0 && is_ephemeral_branch(current_branch.as_deref()) {
+        delete_session_dir(&session_dir);
+    } else {
+        eprintln!("orangu --resume {session_id}");
+    }
     Ok(())
 }
 
@@ -709,6 +724,13 @@ fn handle_command(
                 Ok(()) => Ok(CommandOutcome::Quiet),
                 Err(err) => Ok(CommandOutcome::Output(format!("Error: {err:#}"))),
             }
+        }
+        LocalCommand::Session(None) => match list_sessions_output(None) {
+            Ok(output) => Ok(CommandOutcome::Output(output)),
+            Err(err) => Ok(local_command_error(err)),
+        },
+        LocalCommand::Session(Some(uuid)) => {
+            Ok(CommandOutcome::Output(format!("orangu --resume {uuid}")))
         }
         LocalCommand::Sessions(filter) => match list_sessions_output(filter.as_deref()) {
             Ok(output) => Ok(CommandOutcome::Output(output)),
@@ -1084,6 +1106,8 @@ struct SessionMetadata {
     started_at: u64,
     last_updated_at: u64,
     workspace: String,
+    #[serde(default)]
+    branch: Option<String>,
 }
 
 fn current_unix_timestamp() -> u64 {
@@ -1167,6 +1191,58 @@ fn update_session_metadata_timestamp(path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn find_session_for_workspace_branch(workspace: &str, branch: Option<&str>) -> Option<String> {
+    let sessions_dir = home::home_dir()?.join(SESSIONS_DIRECTORY);
+    if !sessions_dir.exists() {
+        return None;
+    }
+    let mut candidates: Vec<(String, u64)> = Vec::new();
+    for entry in std::fs::read_dir(&sessions_dir).ok()?.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(uuid) = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        let Some(meta) = load_session_metadata(&path.join("metadata")).ok().flatten() else {
+            continue;
+        };
+        if meta.workspace != workspace {
+            continue;
+        }
+        if meta.branch.as_deref() != branch {
+            continue;
+        }
+        let has_messages = path
+            .join("messages")
+            .metadata()
+            .map(|m| m.len() > 2)
+            .unwrap_or(false);
+        if !has_messages {
+            continue;
+        }
+        candidates.push((uuid, meta.last_updated_at));
+    }
+    if candidates.len() == 1 {
+        Some(candidates.remove(0).0)
+    } else {
+        None
+    }
+}
+
+fn is_ephemeral_branch(branch: Option<&str>) -> bool {
+    matches!(branch, None | Some("main") | Some("master"))
+}
+
+fn delete_session_dir(session_dir: &Path) {
+    let _ = std::fs::remove_dir_all(session_dir);
+}
+
 fn list_sessions_output(workspace_filter: Option<&str>) -> Result<String> {
     let sessions_dir = {
         let home = home::home_dir().ok_or_else(|| anyhow!("failed to resolve home directory"))?;
@@ -1217,8 +1293,8 @@ fn list_sessions_output(workspace_filter: Option<&str>) -> Result<String> {
 
     let mut lines: Vec<String> = Vec::new();
     lines.push(format!(
-        "{:<36}  {:<12}  {:<12}  {:>4}  {}",
-        "UUID", "STARTED", "LAST", "CMDS", "WORKSPACE"
+        "{:<36}  {:<12}  {:<12}  {:>4}  {:<24}  {}",
+        "UUID", "STARTED", "LAST", "CMDS", "BRANCH", "WORKSPACE"
     ));
     for (uuid, meta, cmd_count) in &entries {
         let started = meta
@@ -1229,10 +1305,14 @@ fn list_sessions_output(workspace_filter: Option<&str>) -> Result<String> {
             .as_ref()
             .map(|m| format_unix_timestamp(m.last_updated_at))
             .unwrap_or_else(|| "-".to_string());
+        let branch = meta
+            .as_ref()
+            .and_then(|m| m.branch.as_deref())
+            .unwrap_or("-");
         let workspace = meta.as_ref().map(|m| m.workspace.as_str()).unwrap_or("-");
         lines.push(format!(
-            "{:<36}  {:<12}  {:<12}  {:>4}  {}",
-            uuid, started, last, cmd_count, workspace
+            "{:<36}  {:<12}  {:<12}  {:>4}  {:<24}  {}",
+            uuid, started, last, cmd_count, branch, workspace
         ));
     }
     Ok(lines.join("\n"))

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -156,6 +156,7 @@ pub fn help_text() -> &'static str {
 /squash                                       Squash all branch commits into one
 /delete <branch>                              Delete a local branch with git branch -D
 /open_file <path>                             Open a workspace file in $EDITOR
+/session [uuid]                               List sessions or print resume command for a UUID (Tab cycles UUIDs)
 /sessions [workspace]                         List all sessions, optionally filtered by workspace path
 /usage                                        Show usage statistics for this session
 /clear                                        Clear the current conversation


### PR DESCRIPTION
- Add `branch: Option<String>` to SessionMetadata (#[serde(default)] for backward compat)
- On startup, auto-detect workspace + branch and silently resume the matching session if exactly one non-empty match exists; print "Resuming session <uuid>" before TUI
- On exit, delete session directory if zero LLM queries and on main/master/no-branch (feature branch sessions always persist); skip resume command print when deleted
- Add /session [uuid] command: no arg lists sessions, uuid arg prints resume command
- Add /session <TAB> completion cycling session UUIDs newest-to-oldest via mtime
- Add BRANCH column to /sessions output