### PR TITLE
feat(#41): add quotes config property shown during thinking mode

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -23,6 +23,7 @@ max_tool_rounds = 10
 | `model` | Yes, if multiple profiles exist | Default profile name |
 | `timeout` | No | Request timeout in seconds. Defaults to `1800` |
 | `max_tool_rounds` | No | Maximum tool-calling turns per prompt. Defaults to `10` |
+| `quotes` | No | Quote set shown while the model is thinking. Defaults to `none`. Options: `none`, `star_trek`, `star_wars`, `marco_pierre_white`, `gordon_ramsay`, `calvin_and_hobbes`, `all` |
 
 ## Model sections
 

--- a/doc/etc/orangu.conf
+++ b/doc/etc/orangu.conf
@@ -2,6 +2,7 @@
 model = gemma-4-E4B-it-GGUF
 timeout = 1800
 max_tool_rounds = 10
+# quotes = none
 
 [gemma-4-E4B-it-GGUF]
 provider = llama.cpp

--- a/doc/manual/en/20-configuration.md
+++ b/doc/manual/en/20-configuration.md
@@ -20,6 +20,7 @@ max_tool_rounds = 10
 | `model` | Yes, if multiple profiles exist | Default profile name |
 | `timeout` | No | Request timeout in seconds. The default is `1800` |
 | `max_tool_rounds` | No | Maximum tool-calling turns before the client aborts the prompt |
+| `quotes` | No | Quote set shown while the model is thinking. Defaults to `none`. Options: `none`, `star_trek`, `star_wars`, `marco_pierre_white`, `gordon_ramsay`, `calvin_and_hobbes`, `all` |
 
 ## Model profiles
 

--- a/src/bin/orangu/input.rs
+++ b/src/bin/orangu/input.rs
@@ -155,6 +155,7 @@ pub struct WaitContext<'a> {
     pub output_state: &'a mut OutputState,
     pub input_state: &'a mut InputState,
     pub pending_commands: &'a mut VecDeque<String>,
+    pub thinking_quote: Option<&'static str>,
 }
 
 #[derive(Default)]

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -18,6 +18,7 @@ mod commands;
 mod completion;
 mod git;
 mod input;
+mod quotes;
 mod render;
 
 use anyhow::{Context, Result, anyhow};
@@ -113,6 +114,7 @@ async fn run() -> Result<()> {
         }
     };
     let config = load_client_configuration(&config_path)?;
+    let quote_module = quotes::QuoteModule::from_str(&config.quotes);
     let workspace = resolve_workspace_root(args.workspace)?;
     let tools = ToolExecutor::new(&workspace);
 
@@ -355,6 +357,7 @@ async fn run() -> Result<()> {
                         output_state: &mut output_state,
                         input_state: &mut input_state,
                         pending_commands: &mut pending_commands,
+                        thinking_quote: None,
                     },
                     handle,
                 )
@@ -385,6 +388,7 @@ async fn run() -> Result<()> {
                         output_state: &mut output_state,
                         input_state: &mut input_state,
                         pending_commands: &mut pending_commands,
+                        thinking_quote: None,
                     },
                     handle,
                 )
@@ -420,6 +424,11 @@ async fn run() -> Result<()> {
         prompt_profile.endpoint = endpoint.to_string();
         let llm_start = std::time::Instant::now();
         let tool_time_before = tools.total_tool_duration();
+        let seed = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let thinking_quote = quote_module.pick(seed);
         match wait_for_response(
             &mut session,
             &next_input,
@@ -440,6 +449,7 @@ async fn run() -> Result<()> {
                 output_state: &mut output_state,
                 input_state: &mut input_state,
                 pending_commands: &mut pending_commands,
+                thinking_quote,
             },
         )
         .await
@@ -916,6 +926,7 @@ async fn wait_for_response(
         output_state,
         input_state,
         pending_commands,
+        thinking_quote,
     } = wait_context;
     let streamed_state = Arc::new(Mutex::new(StreamRenderState::default()));
     let prompt_output = Arc::clone(&streamed_state);
@@ -954,6 +965,7 @@ async fn wait_for_response(
     let mut last_tool_was_running = false;
     let mut escape_cancel_state = EscapeCancelState::default();
     let initial_status = render_thinking_status(thinking_frame, thinking_started.elapsed());
+    let quote_line = thinking_quote.map(|q| format!("\x1b[2m{q}\x1b[0m"));
 
     print_screen(
         render,
@@ -962,7 +974,7 @@ async fn wait_for_response(
             scroll_offset: output_state.scroll_offset(),
             left_status: Some(initial_status),
             pending_count: pending_commands.len(),
-            pending_line: None,
+            pending_line: quote_line.as_deref(),
             input: input_state.as_str(),
             cursor: input_state.cursor(),
         },
@@ -1073,7 +1085,7 @@ async fn wait_for_response(
                         tokenizer.as_ref(),
                     );
                     let pending_line = if last_rendered_output.is_empty() {
-                        String::new()
+                        quote_line.clone().unwrap_or_default()
                     } else {
                         render_markdown_for_console(&last_rendered_output)
                     };
@@ -1109,6 +1121,7 @@ async fn wait_for_local_command(
         output_state,
         input_state,
         pending_commands,
+        thinking_quote: _,
     } = wait_context;
     let started = std::time::Instant::now();
     let mut interval = tokio::time::interval(WAIT_LOOP_POLL_INTERVAL);

--- a/src/bin/orangu/quotes.rs
+++ b/src/bin/orangu/quotes.rs
@@ -1,0 +1,192 @@
+// Copyright (C) 2026 The orangu community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+pub enum QuoteModule {
+    None,
+    StarTrek,
+    StarWars,
+    MarcoPierreWhite,
+    GordonRamsay,
+    CalvinAndHobbes,
+    All,
+}
+
+impl QuoteModule {
+    pub fn from_str(s: &str) -> Self {
+        match s.trim().to_lowercase().as_str() {
+            "star_trek" => Self::StarTrek,
+            "star_wars" => Self::StarWars,
+            "marco_pierre_white" => Self::MarcoPierreWhite,
+            "gordon_ramsay" => Self::GordonRamsay,
+            "calvin_and_hobbes" => Self::CalvinAndHobbes,
+            "all" => Self::All,
+            _ => Self::None,
+        }
+    }
+
+    pub fn pick(&self, seed: u64) -> Option<&'static str> {
+        let pool: &[&[&str]] = match self {
+            Self::None => return None,
+            Self::StarTrek => &[STAR_TREK],
+            Self::StarWars => &[STAR_WARS],
+            Self::MarcoPierreWhite => &[MARCO_PIERRE_WHITE],
+            Self::GordonRamsay => &[GORDON_RAMSAY],
+            Self::CalvinAndHobbes => &[CALVIN_AND_HOBBES],
+            Self::All => &[
+                STAR_TREK,
+                STAR_WARS,
+                MARCO_PIERRE_WHITE,
+                GORDON_RAMSAY,
+                CALVIN_AND_HOBBES,
+            ],
+        };
+        let total: usize = pool.iter().map(|s| s.len()).sum();
+        if total == 0 {
+            return None;
+        }
+        let mut idx = seed as usize % total;
+        for slice in pool {
+            if idx < slice.len() {
+                return Some(slice[idx]);
+            }
+            idx -= slice.len();
+        }
+        None
+    }
+}
+
+static STAR_TREK: &[&str] = &[
+    "Space: the final frontier. These are the voyages of the starship Enterprise.",
+    "Live long and prosper.",
+    "Make it so.",
+    "Resistance is futile.",
+    "He's dead, Jim.",
+    "I'm a doctor, not a bricklayer.",
+    "To boldly go where no man has gone before.",
+    "Fascinating.",
+    "Engage.",
+    "The needs of the many outweigh the needs of the few.",
+];
+
+static STAR_WARS: &[&str] = &[
+    "May the Force be with you.",
+    "Do. Or do not. There is no try.",
+    "I am your father.",
+    "I've got a bad feeling about this.",
+    "In my experience, there is no such thing as luck.",
+    "The Force will be with you, always.",
+    "That's no moon.",
+    "Help me, Obi-Wan Kenobi. You're my only hope.",
+    "It's a trap!",
+    "Never tell me the odds.",
+];
+
+static MARCO_PIERRE_WHITE: &[&str] = &[
+    "Cooking is the easy part. Doing it every day is the hard part.",
+    "I cook for people, not for critics.",
+    "The more you learn, the more you realize how little you know.",
+    "Perfection is a lot of little things done well.",
+    "Nature is the true artist; the chef is merely the cook.",
+    "When you understand an ingredient, you understand the dish.",
+    "Give a man a fish and you feed him for a day. Teach a man to fish and you feed him for life.",
+];
+
+static GORDON_RAMSAY: &[&str] = &[
+    "This chicken is so raw it's still asking why it crossed the road.",
+    "A recipe has no soul. You, as the cook, must bring soul to the recipe.",
+    "Cooking today is a young man's game — I don't give a bollocks what anyone says.",
+    "I don't like looking back. I'm always constantly looking forward.",
+    "Kitchens are hard environments and they form incredibly strong characters.",
+    "I taught myself to cook — that is what makes me a truly self-made chef.",
+    "The secret of a good restaurant: find great ingredients and don't ruin them.",
+];
+
+static CALVIN_AND_HOBBES: &[&str] = &[
+    "It's a magical world, Hobbes, ol' buddy... let's go exploring!",
+    "Sometimes I think the surest sign that intelligent life exists elsewhere in the universe is that none of it has tried to contact us.",
+    "Reality continues to ruin my life.",
+    "I go to school, but I never learn what I want to know.",
+    "Life is like topography, Hobbes. There are summits of happiness and success, flat stretches of boring routine, and valleys of frustration and failure.",
+    "I'm not dumb, I just have a command of thoroughly useless information.",
+    "You can't just turn on creativity like a faucet. You have to be in the right mood. What mood is that? Last-minute panic.",
+    "Weekends don't count unless you spend them doing something completely pointless.",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn none_returns_no_quote() {
+        assert!(QuoteModule::None.pick(0).is_none());
+        assert!(QuoteModule::None.pick(42).is_none());
+    }
+
+    #[test]
+    fn each_module_returns_quotes() {
+        assert!(QuoteModule::StarTrek.pick(0).is_some());
+        assert!(QuoteModule::StarWars.pick(1).is_some());
+        assert!(QuoteModule::MarcoPierreWhite.pick(2).is_some());
+        assert!(QuoteModule::GordonRamsay.pick(3).is_some());
+        assert!(QuoteModule::CalvinAndHobbes.pick(4).is_some());
+    }
+
+    #[test]
+    fn all_covers_every_slot() {
+        let total: usize = [
+            STAR_TREK,
+            STAR_WARS,
+            MARCO_PIERRE_WHITE,
+            GORDON_RAMSAY,
+            CALVIN_AND_HOBBES,
+        ]
+        .iter()
+        .map(|s| s.len())
+        .sum();
+        for seed in 0..total as u64 {
+            assert!(QuoteModule::All.pick(seed).is_some());
+        }
+    }
+
+    #[test]
+    fn from_str_parses_all_variants() {
+        assert!(matches!(QuoteModule::from_str("none"), QuoteModule::None));
+        assert!(matches!(
+            QuoteModule::from_str("star_trek"),
+            QuoteModule::StarTrek
+        ));
+        assert!(matches!(
+            QuoteModule::from_str("star_wars"),
+            QuoteModule::StarWars
+        ));
+        assert!(matches!(
+            QuoteModule::from_str("marco_pierre_white"),
+            QuoteModule::MarcoPierreWhite
+        ));
+        assert!(matches!(
+            QuoteModule::from_str("gordon_ramsay"),
+            QuoteModule::GordonRamsay
+        ));
+        assert!(matches!(
+            QuoteModule::from_str("calvin_and_hobbes"),
+            QuoteModule::CalvinAndHobbes
+        ));
+        assert!(matches!(QuoteModule::from_str("all"), QuoteModule::All));
+        assert!(matches!(
+            QuoteModule::from_str("unknown"),
+            QuoteModule::None
+        ));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ use std::{
 pub struct ClientAppConfiguration {
     pub default_model: String,
     pub llms: HashMap<String, LlmConfiguration>,
+    pub quotes: String,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -48,6 +49,8 @@ struct ClientConfiguration {
     max_tool_rounds: usize,
     #[serde(default)]
     system_prompt: String,
+    #[serde(default)]
+    quotes: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -83,6 +86,7 @@ pub fn load_client_configuration(path: &Path) -> Result<ClientAppConfiguration> 
             root.client.max_tool_rounds,
             root.client.system_prompt,
         )?,
+        quotes: root.client.quotes,
     })
 }
 


### PR DESCRIPTION
Closes #41

Adds a quotes property to orangu.conf that shows a random quote while the model is thinking. Set to star_trek to enable, defaults to none.