### PR TITLE
[#15] Pending

### DIFF
--- a/src/bin/orangu/commands/mod.rs
+++ b/src/bin/orangu/commands/mod.rs
@@ -150,6 +150,8 @@ pub enum CommandOutcome {
     Export(ExportTarget),
     /// Enter the built-in manual viewer.
     Manual,
+    PendingList,
+    PendingDelete(usize),
 }
 
 /// Data handed to the interactive review mode: the changed files, each with its
@@ -269,6 +271,8 @@ pub enum LocalCommand<'a> {
     Build,
     Clear,
     Quit,
+    PendingList,
+    PendingDelete(Option<usize>),
 }
 
 pub struct CommandContext<'a> {

--- a/src/bin/orangu/commands/natural.rs
+++ b/src/bin/orangu/commands/natural.rs
@@ -271,6 +271,11 @@ pub const NATURAL_LANGUAGE_BINDINGS: &[&str] = &[
     "prune sessions in ",
     "prune all",
     "prune",
+    // --- pending ---
+    "pending",
+    "list pending",
+    "pending list",
+    "show pending",
     // --- usage ---
     "usage",
     "show usage",
@@ -703,6 +708,12 @@ pub fn parse_natural_language_command(input: &str) -> Option<LocalCommand<'_>> {
     }
     if matches_ci(input, &["prune"]) {
         return Some(LocalCommand::Prune(None));
+    }
+    if matches_ci(
+        input,
+        &["pending", "list pending", "pending list", "show pending"],
+    ) {
+        return Some(LocalCommand::PendingList);
     }
     if matches_ci(input, &["usage", "show usage"]) {
         return Some(LocalCommand::Usage);

--- a/src/bin/orangu/commands/slash.rs
+++ b/src/bin/orangu/commands/slash.rs
@@ -61,6 +61,7 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
         "/usage" => Some(LocalCommand::Usage),
         "/clear" => Some(LocalCommand::Clear),
         "/quit" => Some(LocalCommand::Quit),
+        "/pending" => Some(LocalCommand::PendingList),
         _ => {
             if let Some(args) = input.strip_prefix("/session ") {
                 let uuid = args.trim();
@@ -268,6 +269,16 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
                 && args.trim().is_empty()
             {
                 return Some(LocalCommand::OpenFile(""));
+            }
+            if let Some(args) = input.strip_prefix("/pending ") {
+                let args = args.trim();
+                return Some(if args.eq_ignore_ascii_case("list") || args.is_empty() {
+                    LocalCommand::PendingList
+                } else if let Some(rest) = strip_ascii_prefix(args, "delete") {
+                    LocalCommand::PendingDelete(rest.trim().parse::<usize>().ok())
+                } else {
+                    LocalCommand::PendingList
+                });
             }
             parse_open_file_target(input, "/open_file ").map(LocalCommand::OpenFile)
         }

--- a/src/bin/orangu/commands/tests.rs
+++ b/src/bin/orangu/commands/tests.rs
@@ -1095,3 +1095,39 @@ fn splits_editor_command_and_flags() {
         vec!["/tmp/my editor".to_string(), "--flag".to_string()]
     );
 }
+
+#[test]
+fn parses_pending_commands() {
+    assert!(matches!(
+        parse_local_command("/pending"),
+        Some(LocalCommand::PendingList)
+    ));
+    assert!(matches!(
+        parse_local_command("/pending list"),
+        Some(LocalCommand::PendingList)
+    ));
+    assert!(matches!(
+        parse_local_command("pending"),
+        Some(LocalCommand::PendingList)
+    ));
+    assert!(matches!(
+        parse_local_command("list pending"),
+        Some(LocalCommand::PendingList)
+    ));
+    assert!(matches!(
+        parse_local_command("show pending"),
+        Some(LocalCommand::PendingList)
+    ));
+    assert!(matches!(
+        parse_local_command("/pending delete"),
+        Some(LocalCommand::PendingDelete(None))
+    ));
+    match parse_local_command("/pending delete 2") {
+        Some(LocalCommand::PendingDelete(Some(2))) => {}
+        _ => panic!("expected pending delete 2"),
+    }
+    match parse_local_command("/pending delete 1") {
+        Some(LocalCommand::PendingDelete(Some(1))) => {}
+        _ => panic!("expected pending delete 1"),
+    }
+}

--- a/src/bin/orangu/completion/mod.rs
+++ b/src/bin/orangu/completion/mod.rs
@@ -69,6 +69,7 @@ pub const COMMANDS: &[&str] = &[
     "/squash",
     "/stash",
     "/open_file",
+    "/pending",
     "/session",
     "/manual",
     "/usage",

--- a/src/bin/orangu/dispatch.rs
+++ b/src/bin/orangu/dispatch.rs
@@ -588,6 +588,11 @@ pub(crate) fn handle_command(
             Ok(CommandOutcome::Cleared)
         }
         LocalCommand::Quit => Ok(CommandOutcome::Quit),
+        LocalCommand::PendingList => Ok(CommandOutcome::PendingList),
+        LocalCommand::PendingDelete(None) => Ok(CommandOutcome::Output(
+            "Usage: /pending delete <number>. Use /pending to list.".to_string(),
+        )),
+        LocalCommand::PendingDelete(Some(index)) => Ok(CommandOutcome::PendingDelete(index)),
     }
 }
 
@@ -1157,6 +1162,138 @@ mod tests {
             outcome,
             CommandOutcome::OutputError(ref message)
                 if message == "Unknown command '/unknown'. Use /help to see available commands."
+        ));
+    }
+
+    #[test]
+    fn pending_list_returns_pending_list_outcome() {
+        let llms = HashMap::from([(
+            "llama".to_string(),
+            test_profile("llama.cpp", "http://localhost:8100/v1", "gemma"),
+        )]);
+        let workspace = tempdir().expect("workspace");
+        let tools = ToolExecutor::new(workspace.path());
+        let mut active_model = "llama".to_string();
+        let mut active_model_id = "gemma".to_string();
+        let mut current_endpoint = Some(normalized_openai_endpoint("http://localhost:8100/v1"));
+        let mut session = ChatSession::new("system");
+
+        let outcome = handle_command(
+            "/pending",
+            CommandState {
+                active_model: &mut active_model,
+                active_model_id: &mut active_model_id,
+                current_endpoint: &mut current_endpoint,
+                session: &mut session,
+                detect_model: &mut false,
+            },
+            CommandContext {
+                startup_model: "llama",
+                startup_endpoint: "http://localhost:8100/v1",
+                llms: &llms,
+                tools: &tools,
+                workspace: workspace.path(),
+                usage_stats: &super::UsageStats::new(),
+                available_models: &[],
+                virtual_width: 512,
+                auto_rebase: false,
+                auto_squash: false,
+                terminal: "",
+                forge: crate::git::Forge::GitHub,
+                review_reports: crate::git::ReviewReports::default(),
+            },
+        )
+        .expect("handle command");
+
+        assert!(matches!(outcome, CommandOutcome::PendingList));
+    }
+
+    #[test]
+    fn pending_delete_with_index_returns_pending_delete_outcome() {
+        let llms = HashMap::from([(
+            "llama".to_string(),
+            test_profile("llama.cpp", "http://localhost:8100/v1", "gemma"),
+        )]);
+        let workspace = tempdir().expect("workspace");
+        let tools = ToolExecutor::new(workspace.path());
+        let mut active_model = "llama".to_string();
+        let mut active_model_id = "gemma".to_string();
+        let mut current_endpoint = Some(normalized_openai_endpoint("http://localhost:8100/v1"));
+        let mut session = ChatSession::new("system");
+
+        let outcome = handle_command(
+            "/pending delete 3",
+            CommandState {
+                active_model: &mut active_model,
+                active_model_id: &mut active_model_id,
+                current_endpoint: &mut current_endpoint,
+                session: &mut session,
+                detect_model: &mut false,
+            },
+            CommandContext {
+                startup_model: "llama",
+                startup_endpoint: "http://localhost:8100/v1",
+                llms: &llms,
+                tools: &tools,
+                workspace: workspace.path(),
+                usage_stats: &super::UsageStats::new(),
+                available_models: &[],
+                virtual_width: 512,
+                auto_rebase: false,
+                auto_squash: false,
+                terminal: "",
+                forge: crate::git::Forge::GitHub,
+                review_reports: crate::git::ReviewReports::default(),
+            },
+        )
+        .expect("handle command");
+
+        assert!(matches!(outcome, CommandOutcome::PendingDelete(3)));
+    }
+
+    #[test]
+    fn pending_delete_without_index_returns_usage_output() {
+        let llms = HashMap::from([(
+            "llama".to_string(),
+            test_profile("llama.cpp", "http://localhost:8100/v1", "gemma"),
+        )]);
+        let workspace = tempdir().expect("workspace");
+        let tools = ToolExecutor::new(workspace.path());
+        let mut active_model = "llama".to_string();
+        let mut active_model_id = "gemma".to_string();
+        let mut current_endpoint = Some(normalized_openai_endpoint("http://localhost:8100/v1"));
+        let mut session = ChatSession::new("system");
+
+        let outcome = handle_command(
+            "/pending delete",
+            CommandState {
+                active_model: &mut active_model,
+                active_model_id: &mut active_model_id,
+                current_endpoint: &mut current_endpoint,
+                session: &mut session,
+                detect_model: &mut false,
+            },
+            CommandContext {
+                startup_model: "llama",
+                startup_endpoint: "http://localhost:8100/v1",
+                llms: &llms,
+                tools: &tools,
+                workspace: workspace.path(),
+                usage_stats: &super::UsageStats::new(),
+                available_models: &[],
+                virtual_width: 512,
+                auto_rebase: false,
+                auto_squash: false,
+                terminal: "",
+                forge: crate::git::Forge::GitHub,
+                review_reports: crate::git::ReviewReports::default(),
+            },
+        )
+        .expect("handle command");
+
+        assert!(matches!(
+            outcome,
+            CommandOutcome::Output(ref msg) if msg.contains("Usage")
         ));
     }
 }

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -585,6 +585,16 @@ async fn run() -> Result<()> {
                 output_state.clear();
                 continue;
             }
+            CommandOutcome::PendingList => {
+                output_state.push_text(&format_pending_list(&pending_commands));
+                output_state.reset_scroll();
+                continue;
+            }
+            CommandOutcome::PendingDelete(index) => {
+                apply_pending_delete(index, &mut pending_commands, &mut output_state);
+                output_state.reset_scroll();
+                continue;
+            }
             CommandOutcome::Output(output) => {
                 output_state.push_text(&output);
                 if config.feedback {

--- a/src/bin/orangu/wait.rs
+++ b/src/bin/orangu/wait.rs
@@ -185,15 +185,40 @@ pub(crate) async fn wait_for_response(
                     if let Some(outcome) = result.outcome {
                         match outcome {
                             InputResult::Submitted(line) => {
-                                let had_pending = pending_commands.len();
-                                let _ = prepare_submitted_input(
-                                    &line,
-                                    history,
-                                    history_path,
-                                    output_state,
-                                    Some(pending_commands),
-                                )?;
-                                redraw = redraw || pending_commands.len() != had_pending || !line.trim().is_empty();
+                                match parse_local_command(line.trim()) {
+                                    Some(LocalCommand::PendingList) => {
+                                        output_state
+                                            .push_text(&format_pending_list(pending_commands));
+                                        redraw = true;
+                                    }
+                                    Some(LocalCommand::PendingDelete(Some(index))) => {
+                                        apply_pending_delete(
+                                            index,
+                                            pending_commands,
+                                            output_state,
+                                        );
+                                        redraw = true;
+                                    }
+                                    Some(LocalCommand::PendingDelete(None)) => {
+                                        output_state.push_text(
+                                            "Usage: /pending delete <number>. Use /pending to list.",
+                                        );
+                                        redraw = true;
+                                    }
+                                    _ => {
+                                        let had_pending = pending_commands.len();
+                                        let _ = prepare_submitted_input(
+                                            &line,
+                                            history,
+                                            history_path,
+                                            output_state,
+                                            Some(pending_commands),
+                                        )?;
+                                        redraw = redraw
+                                            || pending_commands.len() != had_pending
+                                            || !line.trim().is_empty();
+                                    }
+                                }
                             }
                             InputResult::Refresh => {}
                             InputResult::Quit => return Ok(WaitResult::Quit),
@@ -436,6 +461,33 @@ pub(crate) fn is_wait_cancel_escape(event: &Event) -> bool {
             ..
         })
     )
+}
+
+pub(crate) fn format_pending_list(pending: &VecDeque<String>) -> String {
+    if pending.is_empty() {
+        "No pending commands.".to_string()
+    } else {
+        let mut lines = vec!["Pending commands:".to_string()];
+        for (i, cmd) in pending.iter().enumerate() {
+            lines.push(format!("  {}. {}", i + 1, cmd));
+        }
+        lines.join("\n")
+    }
+}
+
+pub(crate) fn apply_pending_delete(
+    index: usize,
+    pending: &mut VecDeque<String>,
+    output_state: &mut OutputState,
+) {
+    if index == 0 || index > pending.len() {
+        output_state.push_text(&format!(
+            "No pending command at index {index}. Use /pending to list."
+        ));
+    } else {
+        let removed = pending.remove(index - 1).expect("index validated");
+        output_state.push_text(&format!("Removed: {removed}"));
+    }
 }
 
 pub(crate) fn final_pending_line(streamed_output: &str, response: &str) -> Option<String> {

--- a/src/tui/header.rs
+++ b/src/tui/header.rs
@@ -159,6 +159,7 @@ pub fn help_text() -> &'static str {
 /log [number]                                 Show commit log (optionally the latest number of commits) plus a count of uncommitted/untracked changes
 /merge <branch>                               Merge a branch into the current branch
 /move_file <source> <destination>             Rename or move a tracked file with git mv
+/pending [delete <n>]                         List queued commands, or delete one by number
 /pull <number>                                Check out a GitHub/GitLab pull/merge request on a dedicated branch
 /pull_request                                 Create a pull request for the current branch
 /push [--force]                               Push the current branch to origin
@@ -174,7 +175,7 @@ pub fn help_text() -> &'static str {
 /clear                                        Clear the current conversation
 /quit                                         Exit the client
 
-Natural-language forms such as `open README.md`, `list models`, `list files`, `pull 58`, `log`, `status`, `rebase`, `squash`, `merge feature/foo`, `grep <pattern>`, `find <pattern>`, `branch`, `list branches`, `checkout main`, `switch to main`, `create branch feature/x`, `rename to new-name`, `delete feature/foo`, `restore README.md`, `add README.md`, `remove README.md`, `move old.rs new.rs`, `cherry pick abc1234`, `commit "[#42] My feature"`, `amend "[#42] My feature"`, `push`, `force push`, `add comment on 51 "My comment"`, `comment on 48 with review`, `comment on 48 with auto review`, `get comments for issue 51`, `get comments for pull request 58`, `review`, `auto review`, `export console`, `export review`, `create pull request`, `stash`, `stash pop`, `stash list`, `stash drop`, `init repo`, `prune session <uuid>`, `prune all`, `prune sessions older than <days>`, `prune sessions in <path>`, `restart`, `show manual`, and `show help` are also handled locally.
+Natural-language forms such as `open README.md`, `list models`, `list files`, `pull 58`, `log`, `status`, `rebase`, `squash`, `merge feature/foo`, `grep <pattern>`, `find <pattern>`, `branch`, `list branches`, `checkout main`, `switch to main`, `create branch feature/x`, `rename to new-name`, `delete feature/foo`, `restore README.md`, `add README.md`, `remove README.md`, `move old.rs new.rs`, `cherry pick abc1234`, `commit "[#42] My feature"`, `amend "[#42] My feature"`, `push`, `force push`, `add comment on 51 "My comment"`, `comment on 48 with review`, `comment on 48 with auto review`, `get comments for issue 51`, `get comments for pull request 58`, `review`, `auto review`, `export console`, `export review`, `create pull request`, `stash`, `stash pop`, `stash list`, `stash drop`, `init repo`, `prune session <uuid>`, `prune all`, `prune sessions older than <days>`, `prune sessions in <path>`, `restart`, `pending`, `show manual`, and `show help` are also handled locally.
 
 The prompt uses standard Unix shell keys, including Ctrl+Left, Ctrl+Right, Ctrl+A, Ctrl+E, Ctrl+K, Ctrl+U, Ctrl+W, Alt+Backspace, Alt+D, and Tab completion.
 


### PR DESCRIPTION
Adds `/pending` to list and delete queued commands.

- `/pending` — show the queue with 1-based indices
- `/pending delete <n>` — remove command at position n
- `/pending delete` (no index) — prints usage hint
- Natural-language aliases: `pending`, `list pending`, `show pending`
- Tab completion via COMMANDS list
- `/help` updated
