### PR TITLE
[#35] /pull_request: Create a pull request for the current branch

### DIFF
--- a/doc/CONFIGURATION.md
+++ b/doc/CONFIGURATION.md
@@ -25,6 +25,10 @@ max_tool_rounds = 10
 | `max_tool_rounds` | No | Maximum tool-calling turns per prompt. Defaults to `10` |
 | `quotes` | No | Quote set shown while the model is thinking. Defaults to `none`. Options: `none`, `star_trek`, `star_wars`, `marco_pierre_white`, `gordon_ramsay`, `calvin_and_hobbes`, `all` |
 | `width` | No | Virtual terminal width for the output canvas. Source lines from `/show_file` are laid out at this width and can be panned horizontally. Defaults to `512` |
+| `banner` | No | Horizontal placement of the header banner. Defaults to `left`. Options: `left`, `center`, `right` |
+| `feedback` | No | Show a green or red dot in the output window after each command to indicate success or failure. Defaults to `off`. Options: `on`, `true`, `1`, `off`, `false`, `0` |
+| `auto_rebase` | No | Automatically rebase the branch before `/pull_request` if it is behind the base. Defaults to `off`. Options: `on`, `true`, `1`, `off`, `false`, `0` |
+| `auto_squash` | No | Automatically squash commits before `/pull_request` if more than one commit is ahead of the base. Defaults to `off`. Options: `on`, `true`, `1`, `off`, `false`, `0` |
 
 ## Model sections
 

--- a/doc/etc/orangu.conf
+++ b/doc/etc/orangu.conf
@@ -6,6 +6,8 @@ max_tool_rounds = 10
 # width = 512
 # banner = left
 # feedback = off
+# auto_rebase = off
+# auto_squash = off
 
 [gemma-4-E4B-it-GGUF]
 provider = llama.cpp

--- a/doc/manual/en/20-configuration.md
+++ b/doc/manual/en/20-configuration.md
@@ -24,6 +24,8 @@ max_tool_rounds = 10
 | `width` | No | Virtual terminal width in characters. Controls the layout canvas for `/show_file` output. Defaults to `512` |
 | `banner` | No | Horizontal placement of the banner. Defaults to `left`. Options: `left`, `center`, `right` |
 | `feedback` | No | Show a green or red dot in the output window after each command to indicate success or failure. Defaults to `off`. Options: `on`, `true`, `1`, `off`, `false`, `0` |
+| `auto_rebase` | No | Automatically rebase the branch before `/pull_request` if it is behind the base. Defaults to `off`. Options: `on`, `true`, `1`, `off`, `false`, `0` |
+| `auto_squash` | No | Automatically squash commits before `/pull_request` if more than one commit is ahead of the base. Defaults to `off`. Options: `on`, `true`, `1`, `off`, `false`, `0` |
 
 ## Model profiles
 

--- a/doc/manual/en/40-terminal.md
+++ b/doc/manual/en/40-terminal.md
@@ -178,6 +178,7 @@ All slash commands are handled locally. They are not sent to the model.
 | `/merge <branch>` | Merge a branch into the current branch |
 | `/move_file <source> <destination>` | Rename or move a tracked file with git mv |
 | `/pull <number>` | Check out a GitHub pull request on a dedicated branch |
+| `/pull_request` | Create a pull request for the current branch |
 | `/push [--force]` | Push the current branch to origin |
 | `/rebase` | Rebase the current branch against master/main |
 | `/remove_file <path>` | Remove a file or directory from Git tracking |
@@ -201,6 +202,7 @@ Free-form prompts are blocked when the server or model status in the header is r
 - `/status` requires a Git repository and runs `git status --branch --short`; `gh` has no equivalent so it always uses plain Git; added files and untracked entries are shown in green, deleted entries in red, and modified entries in the default terminal color; the branch line is shown in a muted color
 - `/log` requires a Git repository; if a `lg` alias is found in `~/.gitconfig` it runs `git lg`, otherwise it falls back to `git log --graph --oneline --decorate`; see the optional tools chapter for the recommended `git lg` alias setup
 - `/pull <number>` requires a Git repository; if `gh` is installed it uses `gh pr checkout`, otherwise it fetches the pull request directly from `origin`
+- `/pull_request` requires a Git repository and the `gh` CLI; it runs several pre-flight checks before creating the pull request: it blocks on `main` and `master`, requires at least one commit ahead of the base branch, blocks if the branch is behind the base (suggesting `/rebase`), and blocks if there is more than one commit ahead (suggesting `/squash`); when all checks pass it pushes the branch with `--set-upstream origin` and calls `gh pr create` with the title and body derived from the single commit message; the checks can be bypassed by setting `auto_rebase = on` or `auto_squash = on` in the `[orangu]` config section, which triggers the corresponding fix automatically before continuing
 - `/rebase` requires a Git repository; if `gh` is installed it queries the repository default branch, otherwise it probes `origin/main` then `origin/master`
 - `/merge <branch>` requires a Git repository; if `gh` is installed it uses `gh pr merge --merge`, otherwise it uses `git merge`
 - `/checkout <branch|file>` requires a Git repository and runs `git checkout`; Tab completion offers branch names first, then workspace file paths
@@ -248,6 +250,7 @@ Local commands can also be entered in plain language. Examples:
 - `cherry pick abc1234` or `cherry-pick abc1234` or `git cherry-pick abc1234`
 - `commit "[#42] My feature"` or `commit Fix the bug` or `git commit -m "Fix the bug"`
 - `amend "[#42] My feature"` or `amend Fix the bug` or `git amend "[#42] My feature"` or `git commit --amend -m "Fix the bug"`
+- `pull request` or `create pull request` or `open pull request` or `create pr` or `open pr`
 - `push` or `git push` or `git push origin`
 - `force push` or `push force` or `push --force`
 - `init` or `init repo` or `git init`

--- a/doc/manual/en/72-extra.md
+++ b/doc/manual/en/72-extra.md
@@ -76,7 +76,7 @@ Please refer to the upstream documentation for full installation and configurati
 
 [**gh**](https://cli.github.com/) is the official GitHub CLI. It provides commands such as `gh repo clone`, `gh pr create`, and `gh issue list` for interacting with GitHub repositories directly from the terminal.
 
-If it is installed, **orangu** will use it for `/pull` to check out pull requests, for `/rebase` to determine the default branch, and for `/merge` to merge pull requests. Without it, **orangu** falls back to plain Git for all three operations. The `/comment` command does require `gh` and runs `gh issue comment` to add a comment to a GitHub issue; there is no plain Git fallback for it.
+If it is installed, **orangu** will use it for `/pull` to check out pull requests, for `/rebase` to determine the default branch, and for `/merge` to merge pull requests. Without it, **orangu** falls back to plain Git for all three operations. The `/comment` command requires `gh` and runs `gh issue comment` to add a comment to a GitHub issue; there is no plain Git fallback for it. The `/pull_request` command also requires `gh` and runs `gh pr create` to open a pull request from the current branch; there is no plain Git fallback for it.
 
 **Installation**
 

--- a/src/bin/orangu/commands.rs
+++ b/src/bin/orangu/commands.rs
@@ -132,6 +132,7 @@ pub enum LocalCommand<'a> {
     Log,
     Pull(Option<u64>),
     Comment(Option<(u64, Cow<'a, str>)>),
+    CreatePullRequest,
     Rebase,
     Merge(Option<Cow<'a, str>>),
     Checkout(Option<Cow<'a, str>>),
@@ -163,6 +164,8 @@ pub struct CommandContext<'a> {
     pub usage_stats: &'a crate::UsageStats,
     pub http_client: reqwest::Client,
     pub virtual_width: usize,
+    pub auto_rebase: bool,
+    pub auto_squash: bool,
 }
 
 pub struct CommandState<'a> {
@@ -208,6 +211,7 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
         "/move_file" => Some(LocalCommand::MoveFile(None)),
         "/pull" => Some(LocalCommand::Pull(None)),
         "/comment" => Some(LocalCommand::Comment(None)),
+        "/pull_request" => Some(LocalCommand::CreatePullRequest),
         "/push" => Some(LocalCommand::Push(false)),
         "/rebase" => Some(LocalCommand::Rebase),
         "/remove_file" => Some(LocalCommand::RemoveFile(None)),
@@ -459,6 +463,20 @@ pub fn parse_natural_language_command(input: &str) -> Option<LocalCommand<'_>> {
         if let Some(rest) = strip_ascii_prefix(input, prefix) {
             return Some(LocalCommand::Comment(parse_comment_args(rest.trim())));
         }
+    }
+    if matches_ci(
+        input,
+        &[
+            "pull request",
+            "create pull request",
+            "open pull request",
+            "new pull request",
+            "create pr",
+            "open pr",
+            "new pr",
+        ],
+    ) {
+        return Some(LocalCommand::CreatePullRequest);
     }
     if matches_ci(input, &["rebase", "git rebase"]) {
         return Some(LocalCommand::Rebase);

--- a/src/bin/orangu/completion.rs
+++ b/src/bin/orangu/completion.rs
@@ -47,6 +47,7 @@ pub const COMMANDS: &[&str] = &[
     "/cherry_pick",
     "/commit",
     "/amend",
+    "/pull_request",
     "/push",
     "/init_repo",
     "/squash",

--- a/src/bin/orangu/git.rs
+++ b/src/bin/orangu/git.rs
@@ -770,6 +770,137 @@ pub fn comment_output(workspace: &Path, issue_number: u64, body: &str) -> Result
     })
 }
 
+pub fn create_pull_request_output(
+    workspace: &Path,
+    auto_rebase: bool,
+    auto_squash: bool,
+) -> Result<String> {
+    let repo_root = discover_git_root(workspace)
+        .ok_or_else(|| anyhow!("pull_request is only available inside a Git repository"))?;
+    let current = git_current_branch(&repo_root)?;
+    if is_protected_branch(&current) {
+        return Err(anyhow!(
+            "cannot create a pull request from the '{}' branch",
+            current
+        ));
+    }
+    let base_ref = git_find_base_ref(&repo_root)?;
+    let ahead = git_commit_count(&repo_root, &format!("{base_ref}..HEAD"))?;
+    if ahead == 0 {
+        return Err(anyhow!(
+            "no commits ahead of {base_ref}; make at least one commit before opening a pull request"
+        ));
+    }
+    let behind = git_commit_count(&repo_root, &format!("HEAD..{base_ref}"))?;
+    if behind > 0 {
+        if auto_rebase {
+            rebase_output(workspace)?;
+        } else {
+            return Err(anyhow!(
+                "branch is {behind} commit{} behind {base_ref}; run /rebase first",
+                if behind == 1 { "" } else { "s" }
+            ));
+        }
+    }
+    let ahead = git_commit_count(&repo_root, &format!("{base_ref}..HEAD"))?;
+    if ahead > 1 {
+        if auto_squash {
+            squash_output(workspace)?;
+        } else {
+            return Err(anyhow!(
+                "{ahead} commits ahead of {base_ref}; run /squash first"
+            ));
+        }
+    }
+    try_gh_create_pr(&repo_root, &current, &base_ref)
+}
+
+fn git_commit_count(repo_root: &Path, range: &str) -> Result<usize> {
+    Ok(String::from_utf8_lossy(
+        &std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo_root)
+            .args(["rev-list", "--count", range])
+            .output()
+            .context("failed to run git rev-list")?
+            .stdout,
+    )
+    .trim()
+    .parse()
+    .unwrap_or(0))
+}
+
+pub fn try_gh_create_pr(repo_root: &Path, branch: &str, base_ref: &str) -> Result<String> {
+    let full_message = String::from_utf8_lossy(
+        &std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo_root)
+            .args(["log", "-1", "--format=%B"])
+            .output()
+            .context("failed to run git log")?
+            .stdout,
+    )
+    .trim()
+    .to_string();
+    let (title, body) = match full_message.split_once('\n') {
+        Some((subject, rest)) => (subject.trim().to_string(), rest.trim().to_string()),
+        None => (full_message.clone(), String::new()),
+    };
+    if title.is_empty() {
+        return Err(anyhow!(
+            "commit message is empty; cannot derive a pull request title"
+        ));
+    }
+    let push = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["push", "--set-upstream", "origin", branch])
+        .output()
+        .context("failed to run git push")?;
+    if !push.status.success() {
+        let stderr = String::from_utf8_lossy(&push.stderr).trim().to_string();
+        return Err(anyhow!(
+            "git push failed{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    let base = base_ref.trim_start_matches("origin/");
+    let output = match std::process::Command::new("gh")
+        .args([
+            "pr", "create", "--title", &title, "--body", &body, "--base", base,
+        ])
+        .current_dir(repo_root)
+        .output()
+    {
+        Ok(output) => output,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(anyhow!("pull_request requires the gh CLI to be installed"));
+        }
+        Err(err) => return Err(err).context("failed to run gh"),
+    };
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!(
+            "gh pr create failed{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(if stdout.is_empty() {
+        format!("Created pull request from '{branch}'")
+    } else {
+        stdout
+    })
+}
+
 pub fn rebase_output(workspace: &Path) -> Result<String> {
     let repo_root = discover_git_root(workspace)
         .ok_or_else(|| anyhow!("rebase is only available inside a Git repository"))?;

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -63,10 +63,10 @@ use commands::{
 };
 use git::{
     add_file_output, amend_output, checkout_output, cherry_pick_output, comment_output,
-    commit_output, delete_branch_output, git_diff_against_branch, git_workspace_diff,
-    init_repo_output, list_workspace_files_tree, log_output, merge_output, move_file_output,
-    open_in_editor, pull_request_output, push_output, rebase_output, remove_file_output,
-    squash_output, status_output, workspace_branch_name,
+    commit_output, create_pull_request_output, delete_branch_output, git_diff_against_branch,
+    git_workspace_diff, init_repo_output, list_workspace_files_tree, log_output, merge_output,
+    move_file_output, open_in_editor, pull_request_output, push_output, rebase_output,
+    remove_file_output, squash_output, status_output, workspace_branch_name,
 };
 use input::{
     EscapeCancelState, InputContext, InputResult, InputState, InterruptState, OutputState,
@@ -354,6 +354,8 @@ async fn run() -> Result<()> {
                 usage_stats: &usage_stats,
                 http_client: status_http_client.clone(),
                 virtual_width: viewport.virtual_width,
+                auto_rebase: config.auto_rebase,
+                auto_squash: config.auto_squash,
             },
         )? {
             CommandOutcome::Quit => {
@@ -793,6 +795,8 @@ fn handle_command(
         usage_stats,
         http_client,
         virtual_width,
+        auto_rebase,
+        auto_squash,
     } = context;
 
     match command {
@@ -927,6 +931,12 @@ fn handle_command(
                 Ok(_) => Ok(CommandOutcome::Quiet),
                 Err(err) => Ok(local_command_error(err)),
             }
+        }
+        LocalCommand::CreatePullRequest => {
+            let ws = workspace.to_path_buf();
+            Ok(CommandOutcome::Blocking(Box::new(move || {
+                create_pull_request_output(&ws, auto_rebase, auto_squash)
+            })))
         }
         LocalCommand::Rebase => match rebase_output(workspace) {
             Ok(_) => Ok(CommandOutcome::Quiet),
@@ -2275,6 +2285,8 @@ mod tests {
                 usage_stats: &super::UsageStats::new(),
                 http_client: reqwest::Client::new(),
                 virtual_width: 512,
+                auto_rebase: false,
+                auto_squash: false,
             },
         )
         .expect("handle command");
@@ -2451,6 +2463,8 @@ mod tests {
                     usage_stats: &super::UsageStats::new(),
                     http_client: reqwest::Client::new(),
                     virtual_width: 512,
+                    auto_rebase: false,
+                    auto_squash: false,
                 },
             )
             .expect("handle command");
@@ -2510,6 +2524,8 @@ mod tests {
                 usage_stats: &super::UsageStats::new(),
                 http_client: reqwest::Client::new(),
                 virtual_width: 512,
+                auto_rebase: false,
+                auto_squash: false,
             },
         )
         .expect("handle command");
@@ -2793,6 +2809,8 @@ mod tests {
                 usage_stats: &super::UsageStats::new(),
                 http_client: reqwest::Client::new(),
                 virtual_width: 512,
+                auto_rebase: false,
+                auto_squash: false,
             },
         )
         .expect("handle command");
@@ -2842,6 +2860,8 @@ mod tests {
                 usage_stats: &super::UsageStats::new(),
                 http_client: reqwest::Client::new(),
                 virtual_width: 512,
+                auto_rebase: false,
+                auto_squash: false,
             },
         )
         .expect("command outcome");

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,8 @@ pub struct ClientAppConfiguration {
     #[serde(skip)]
     pub banner: Banner,
     pub feedback: bool,
+    pub auto_rebase: bool,
+    pub auto_squash: bool,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -63,6 +65,10 @@ struct ClientConfiguration {
     banner: String,
     #[serde(default)]
     feedback: String,
+    #[serde(default)]
+    auto_rebase: String,
+    #[serde(default)]
+    auto_squash: String,
 }
 
 pub fn default_virtual_width() -> usize {
@@ -110,6 +116,8 @@ pub fn load_client_configuration(path: &Path) -> Result<ClientAppConfiguration> 
         width: root.client.width,
         banner: root.client.banner.parse().unwrap_or_default(),
         feedback: parse_feedback_bool(&root.client.feedback),
+        auto_rebase: parse_feedback_bool(&root.client.auto_rebase),
+        auto_squash: parse_feedback_bool(&root.client.auto_squash),
     })
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -196,6 +196,7 @@ pub fn help_text() -> &'static str {
 /merge <branch>                               Merge a branch into the current branch
 /move_file <source> <destination>             Rename or move a tracked file with git mv
 /pull <number>                                Check out a GitHub pull request on a dedicated branch
+/pull_request                                 Create a pull request for the current branch
 /push [--force]                               Push the current branch to origin
 /rebase                                       Rebase the current branch against master/main
 /remove_file <path>                           Remove a file or directory from Git tracking
@@ -205,7 +206,7 @@ pub fn help_text() -> &'static str {
 /clear                                        Clear the current conversation
 /quit                                         Exit the client
 
-Natural-language forms such as `open README.md`, `list models`, `list files`, `pull 58`, `log`, `status`, `rebase`, `squash`, `merge feature/foo`, `checkout main`, `add README.md`, `remove README.md`, `move old.rs new.rs`, `cherry pick abc1234`, `commit "[#42] My feature"`, `amend "[#42] My feature"`, `push`, `force push`, `add comment on 51 "My comment"`, `init repo`, `delete feature/foo`, and `show help` are also handled locally.
+Natural-language forms such as `open README.md`, `list models`, `list files`, `pull 58`, `log`, `status`, `rebase`, `squash`, `merge feature/foo`, `checkout main`, `add README.md`, `remove README.md`, `move old.rs new.rs`, `cherry pick abc1234`, `commit "[#42] My feature"`, `amend "[#42] My feature"`, `push`, `force push`, `add comment on 51 "My comment"`, `create pull request`, `init repo`, `delete feature/foo`, and `show help` are also handled locally.
 
 The prompt uses standard Unix shell keys, including Ctrl+Left, Ctrl+Right, Ctrl+A, Ctrl+E, Ctrl+K, Ctrl+U, Ctrl+W, Alt+Backspace, Alt+D, and Tab completion.
 


### PR DESCRIPTION
- /pull_request (+ natural language: create/open/new pull request, create/open/new pr)
- Pre-flight checks before creating:
  - blocks on protected branches (main/master)
  - blocks if no commits ahead of base
  - blocks if branch is behind base: errors with /rebase hint, or auto-rebases if auto_rebase = on
  - blocks if multiple commits ahead: errors with /squash hint, or auto-squashes if auto_squash = on
- auto_rebase and auto_squash config options (both off by default)
- Pushes branch to origin with --set-upstream before opening PR
- Title and body derived from the single commit message
- Shells out to gh pr create; errors if gh CLI is not installed
- Tab-completion includes /pull_request