### PR TITLE
[#64] /stash: Git stash support

### DIFF
--- a/doc/manual/en/40-terminal.md
+++ b/doc/manual/en/40-terminal.md
@@ -190,6 +190,10 @@ All slash commands are handled locally. They are not sent to the model.
 | `/remove_file <path>` | Remove a file or directory from Git tracking |
 | `/review` | Review branch changes against main/master in a split view |
 | `/squash` | Squash all branch commits into one using the first commit message |
+| `/stash` | Save uncommitted changes with git stash push |
+| `/stash pop` | Restore the most recent stash with git stash pop |
+| `/stash list` | List all saved stashes |
+| `/stash drop` | Discard the most recent stash with git stash drop |
 | `/status` | Show working tree status with color highlighting |
 | `/usage` | Show usage statistics for this session |
 | `/clear` | Clear the current conversation |
@@ -223,6 +227,7 @@ Free-form prompts are blocked when the server or model status in the header is r
 - `/push [--force]` requires a Git repository and runs `git push origin <branch>` using the current branch name; `gh` has no equivalent so it always uses plain Git; `--force` (or `-f` or `force`) runs `git push -f origin <branch>` but is blocked on `main` and `master` to prevent accidental history rewrites
 - `/init_repo` runs `git init` in the workspace directory; works both inside and outside an existing Git repository (reinitializing an existing repo is safe); `gh` has no equivalent so it always uses plain Git
 - `/squash` requires a Git repository; squashes all commits on the current branch (relative to `origin/main`, `origin/master`, `main`, or `master`, tried in that order) into a single commit using the oldest commit's message; `gh` has no equivalent so it always uses plain Git; squashing on `main` or `master` is blocked; requires at least two commits on the branch
+- `/stash` requires a Git repository and runs `git stash push` to save all uncommitted changes (both staged and unstaged) to the stash stack; `/stash pop` restores and removes the most recent stash entry with `git stash pop`; `/stash list` shows all stash entries with their index and description; `/stash drop` discards the most recent stash entry with `git stash drop`; `gh` has no stash equivalent so all four operations always use plain Git; running `/stash` with a clean working tree produces an error from Git
 - `/review` requires a Git repository; it opens a full-screen, two-pane review of the branch's changes (local plus committed) against the default branch — see the [review chapter](#review) for the full layout and key bindings; `gh` has no equivalent so it always uses plain Git
 - `/delete <branch>` requires a Git repository and runs `git branch -D`; `gh` has no equivalent so it always uses plain Git; deleting `main` or `master` is blocked; Tab completion offers local branch names excluding `main` and `master`
 - `/sessions [workspace]` lists all sessions found under `~/.orangu/sessions/`; output is one line per session with aligned columns: UUID, start date, last-updated date, command count, branch, and workspace path; sessions are sorted by creation time, most-recent first; an optional workspace argument filters the list to sessions whose workspace path contains the given string; the branch column shows `-` for sessions with no recorded branch
@@ -260,6 +265,10 @@ Local commands can also be entered in plain language. Examples:
 - `commit "[#42] My feature"` or `commit Fix the bug` or `git commit -m "Fix the bug"`
 - `amend "[#42] My feature"` or `amend Fix the bug` or `git amend "[#42] My feature"` or `git commit --amend -m "Fix the bug"`
 - `pull request` or `create pull request` or `open pull request` or `create pr` or `open pr`
+- `stash` or `git stash` or `git stash push`
+- `stash pop` or `pop stash` or `git stash pop`
+- `stash list` or `list stashes` or `git stash list`
+- `stash drop` or `drop stash` or `git stash drop`
 - `push` or `git push` or `git push origin`
 - `force push` or `push force` or `push --force`
 - `init` or `init repo` or `git init`

--- a/src/bin/orangu/commands.rs
+++ b/src/bin/orangu/commands.rs
@@ -125,6 +125,13 @@ pub struct ReviewLaunch {
     pub files: Vec<ReviewEntry>,
 }
 
+pub enum StashSubcommand {
+    Push,
+    Pop,
+    List,
+    Drop,
+}
+
 pub enum LocalCommand<'a> {
     Help,
     ConnectDefault,
@@ -156,6 +163,7 @@ pub enum LocalCommand<'a> {
     Push(bool),
     InitRepo,
     Squash,
+    Stash(StashSubcommand),
     DeleteBranch(Option<Cow<'a, str>>),
     OpenFile(&'a str),
     Session(Option<Cow<'a, str>>),
@@ -229,6 +237,7 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
         "/rebase" => Some(LocalCommand::Rebase),
         "/remove_file" => Some(LocalCommand::RemoveFile(None)),
         "/squash" => Some(LocalCommand::Squash),
+        "/stash" => Some(LocalCommand::Stash(StashSubcommand::Push)),
         "/status" => Some(LocalCommand::Status),
         "/usage" => Some(LocalCommand::Usage),
         "/clear" => Some(LocalCommand::Clear),
@@ -344,6 +353,14 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
                 if flag == "--force" || flag == "-f" || flag.eq_ignore_ascii_case("force") {
                     return Some(LocalCommand::Push(true));
                 }
+            }
+            if let Some(sub) = input.strip_prefix("/stash ") {
+                return Some(LocalCommand::Stash(match sub.trim() {
+                    "pop" => StashSubcommand::Pop,
+                    "list" => StashSubcommand::List,
+                    "drop" => StashSubcommand::Drop,
+                    _ => StashSubcommand::Push,
+                }));
             }
             if let Some(args) = input.strip_prefix("/delete ") {
                 let branch = args.trim();
@@ -496,6 +513,18 @@ pub fn parse_natural_language_command(input: &str) -> Option<LocalCommand<'_>> {
         ],
     ) {
         return Some(LocalCommand::CreatePullRequest);
+    }
+    if matches_ci(input, &["stash", "git stash", "git stash push"]) {
+        return Some(LocalCommand::Stash(StashSubcommand::Push));
+    }
+    if matches_ci(input, &["stash pop", "pop stash", "git stash pop"]) {
+        return Some(LocalCommand::Stash(StashSubcommand::Pop));
+    }
+    if matches_ci(input, &["stash list", "list stashes", "git stash list"]) {
+        return Some(LocalCommand::Stash(StashSubcommand::List));
+    }
+    if matches_ci(input, &["stash drop", "drop stash", "git stash drop"]) {
+        return Some(LocalCommand::Stash(StashSubcommand::Drop));
     }
     if matches_ci(input, &["rebase", "git rebase"]) {
         return Some(LocalCommand::Rebase);

--- a/src/bin/orangu/completion.rs
+++ b/src/bin/orangu/completion.rs
@@ -52,6 +52,7 @@ pub const COMMANDS: &[&str] = &[
     "/push",
     "/init_repo",
     "/squash",
+    "/stash",
     "/delete",
     "/open_file",
     "/session",

--- a/src/bin/orangu/git.rs
+++ b/src/bin/orangu/git.rs
@@ -1976,6 +1976,118 @@ pub fn git_delete_branch(repo_root: &Path, branch: &str) -> Result<String> {
     Ok(format!("Deleted branch '{branch}'"))
 }
 
+pub fn stash_output(workspace: &Path) -> Result<String> {
+    let repo_root = discover_git_root(workspace)
+        .ok_or_else(|| anyhow!("stash is only available inside a Git repository"))?;
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_root)
+        .args(["stash", "push"])
+        .output()
+        .context("failed to run git stash push")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!(
+            "git stash push failed{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(if stdout.is_empty() {
+        "Changes stashed".to_string()
+    } else {
+        stdout
+    })
+}
+
+pub fn stash_pop_output(workspace: &Path) -> Result<String> {
+    let repo_root = discover_git_root(workspace)
+        .ok_or_else(|| anyhow!("stash is only available inside a Git repository"))?;
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_root)
+        .args(["stash", "pop"])
+        .output()
+        .context("failed to run git stash pop")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!(
+            "git stash pop failed{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(if stdout.is_empty() {
+        "Stash applied and dropped".to_string()
+    } else {
+        stdout
+    })
+}
+
+pub fn stash_list_output(workspace: &Path) -> Result<String> {
+    let repo_root = discover_git_root(workspace)
+        .ok_or_else(|| anyhow!("stash is only available inside a Git repository"))?;
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_root)
+        .args(["stash", "list"])
+        .output()
+        .context("failed to run git stash list")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!(
+            "git stash list failed{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(if stdout.is_empty() {
+        "No stashes found".to_string()
+    } else {
+        stdout
+    })
+}
+
+pub fn stash_drop_output(workspace: &Path) -> Result<String> {
+    let repo_root = discover_git_root(workspace)
+        .ok_or_else(|| anyhow!("stash is only available inside a Git repository"))?;
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_root)
+        .args(["stash", "drop"])
+        .output()
+        .context("failed to run git stash drop")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!(
+            "git stash drop failed{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(if stdout.is_empty() {
+        "Stash dropped".to_string()
+    } else {
+        stdout
+    })
+}
+
 /// Test helper: initialize a git repo with test user config.
 #[cfg(test)]
 pub fn init_git_for_test(workspace: &Path) {

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -57,11 +57,12 @@ use uuid::Uuid;
 use anyhow::Error;
 use commands::ReviewLaunch;
 use commands::{
-    CommandContext, CommandOutcome, CommandState, LocalCommand, LocalError, add_file_usage_message,
-    amend_usage_message, checkout_usage_message, cherry_pick_usage_message, comment_usage_message,
-    commit_usage_message, connect_usage_message, delete_branch_usage_message, merge_usage_message,
-    model_usage_message, move_file_usage_message, open_file_usage_message, parse_local_command,
-    pull_usage_message, remove_file_usage_message, sorted_model_names, system_prompt,
+    CommandContext, CommandOutcome, CommandState, LocalCommand, LocalError, StashSubcommand,
+    add_file_usage_message, amend_usage_message, checkout_usage_message, cherry_pick_usage_message,
+    comment_usage_message, commit_usage_message, connect_usage_message,
+    delete_branch_usage_message, merge_usage_message, model_usage_message, move_file_usage_message,
+    open_file_usage_message, parse_local_command, pull_usage_message, remove_file_usage_message,
+    sorted_model_names, system_prompt,
 };
 use git::{
     add_file_output, amend_output, checkout_output, cherry_pick_output, collect_review_diff,
@@ -69,7 +70,8 @@ use git::{
     discover_git_root, git_diff_against_branch, git_workspace_diff, init_repo_output,
     list_workspace_files_tree, log_output, merge_output, move_file_output, open_in_editor,
     pull_request_output, push_output, rebase_output, remove_file_output, squash_output,
-    status_output, sync_default_branch, workspace_branch_name,
+    stash_drop_output, stash_list_output, stash_output, stash_pop_output, status_output,
+    sync_default_branch, workspace_branch_name,
 };
 use input::{
     EscapeCancelState, IDLE_STATUS_REFRESH_INTERVAL, InputContext, InputResult, InputState,
@@ -1199,6 +1201,15 @@ fn handle_command(
             Ok(_) => Ok(CommandOutcome::Quiet),
             Err(err) => Ok(local_command_error(err)),
         },
+        LocalCommand::Stash(sub) => {
+            let ws = workspace.to_path_buf();
+            Ok(CommandOutcome::Blocking(Box::new(move || match sub {
+                StashSubcommand::Push => stash_output(&ws),
+                StashSubcommand::Pop => stash_pop_output(&ws),
+                StashSubcommand::List => stash_list_output(&ws),
+                StashSubcommand::Drop => stash_drop_output(&ws),
+            })))
+        }
         LocalCommand::DeleteBranch(None) => Ok(CommandOutcome::OutputError(
             delete_branch_usage_message().to_string(),
         )),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -202,12 +202,16 @@ pub fn help_text() -> &'static str {
 /remove_file <path>                           Remove a file or directory from Git tracking
 /review                                       Review branch changes against main/master in a split view
 /squash                                       Squash all branch commits into one
+/stash                                        Save uncommitted changes (git stash push)
+/stash pop                                    Restore the most recent stash
+/stash list                                   List all saved stashes
+/stash drop                                   Discard the most recent stash
 /status                                       Show working tree status with color highlighting
 /usage                                        Show usage statistics for this session
 /clear                                        Clear the current conversation
 /quit                                         Exit the client
 
-Natural-language forms such as `open README.md`, `list models`, `list files`, `pull 58`, `log`, `status`, `rebase`, `squash`, `merge feature/foo`, `checkout main`, `add README.md`, `remove README.md`, `move old.rs new.rs`, `cherry pick abc1234`, `commit "[#42] My feature"`, `amend "[#42] My feature"`, `push`, `force push`, `add comment on 51 "My comment"`, `review`, `create pull request`, `init repo`, `delete feature/foo`, and `show help` are also handled locally.
+Natural-language forms such as `open README.md`, `list models`, `list files`, `pull 58`, `log`, `status`, `rebase`, `squash`, `merge feature/foo`, `checkout main`, `add README.md`, `remove README.md`, `move old.rs new.rs`, `cherry pick abc1234`, `commit "[#42] My feature"`, `amend "[#42] My feature"`, `push`, `force push`, `add comment on 51 "My comment"`, `review`, `create pull request`, `stash`, `stash pop`, `stash list`, `stash drop`, `init repo`, `delete feature/foo`, and `show help` are also handled locally.
 
 The prompt uses standard Unix shell keys, including Ctrl+Left, Ctrl+Right, Ctrl+A, Ctrl+E, Ctrl+K, Ctrl+U, Ctrl+W, Alt+Backspace, Alt+D, and Tab completion.
 


### PR DESCRIPTION
- /stash: save uncommitted changes (git stash push)
- /stash pop: restore the most recent stash (git stash pop)
- /stash list: list all saved stashes (git stash list)
- /stash drop: discard the most recent stash (git stash drop)
- Natural-language forms: stash, stash pop, pop stash, stash list, list stashes, stash drop, drop stash
- Tab-completion includes /stash
- No gh fallback; all operations use plain Git