### PR TITLE
[#67] /branch and /restore: Consolidate branch management and add file restore

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -50,11 +50,14 @@ orangu --config ./orangu.conf
 - `/build`
 - `/add_file README.md`
 - `/amend <message>`
-- `/checkout main`
+- `/branch main`
+- `/branch -b feature/new`
+- `/branch -m new-name`
+- `/branch -d feature/old`
 - `/cherry_pick <commit>`
 - `/comment 51 "My comment"`
 - `/commit <message>`
-- `/delete feature/foo`
+- `/restore README.md`
 - `/diff`
 - `/init_repo`
 - `/log`

--- a/doc/manual/en/03-quickstart.md
+++ b/doc/manual/en/03-quickstart.md
@@ -67,11 +67,14 @@ Then start with:
 /build
 /add_file README.md
 /amend "[#42] My feature"
-/checkout main
+/branch main
+/branch -b feature/new
+/branch -m new-name
+/branch -d feature/old
 /cherry_pick abc1234
 /comment 51 "My comment"
 /commit "[#42] My feature"
-/delete feature/foo
+/restore README.md
 /diff
 /init_repo
 /log

--- a/doc/manual/en/40-terminal.md
+++ b/doc/manual/en/40-terminal.md
@@ -173,11 +173,10 @@ All slash commands are handled locally. They are not sent to the model.
 | `/build` | Build the workspace project (Rust, C, or Java) |
 | `/add_file <path>` | Stage a file or directory with git add |
 | `/amend <message>` | Rewrite the last commit message |
-| `/checkout <branch\|file>` | Switch branch or restore a file |
+| `/branch [<name>\|-b <name>\|-m <name>\|-d <name>\|-a]` | List, switch, create, rename, or delete branches |
 | `/cherry_pick <commit>` | Cherry-pick a commit onto the current branch |
 | `/comment <number> "<comment>"` | Add a comment to a GitHub issue with gh issue comment |
 | `/commit <message>` | Commit all tracked changes with git commit -a -m |
-| `/delete <branch>` | Delete a local branch |
 | `/diff [branch]` | Show a color unified diff; without a branch shows unstaged changes, with a branch shows changes since diverging from it |
 | `/init_repo` | Initialize a Git repository in the workspace |
 | `/log` | Show commit log (uses `git lg` alias if configured) |
@@ -188,6 +187,7 @@ All slash commands are handled locally. They are not sent to the model.
 | `/push [--force]` | Push the current branch to origin |
 | `/rebase` | Rebase the current branch against master/main |
 | `/remove_file <path>` | Remove a file or directory from Git tracking |
+| `/restore [--staged] <file>` | Restore a file or unstage it with git restore |
 | `/review` | Review branch changes against main/master in a split view |
 | `/squash` | Squash all branch commits into one using the first commit message |
 | `/stash` | Save uncommitted changes with git stash push |
@@ -216,10 +216,11 @@ Free-form prompts are blocked when the server or model status in the header is r
 - `/pull_request` requires a Git repository and the `gh` CLI; it runs several pre-flight checks before creating the pull request: it blocks on `main` and `master`, requires at least one commit ahead of the base branch, blocks if the branch is behind the base (suggesting `/rebase`), and blocks if there is more than one commit ahead (suggesting `/squash`); when all checks pass it pushes the branch with `--set-upstream origin` and calls `gh pr create` with the title and body derived from the single commit message; the checks can be bypassed by setting `auto_rebase = on` or `auto_squash = on` in the `[orangu]` config section, which triggers the corresponding fix automatically before continuing
 - `/rebase` requires a Git repository; if `gh` is installed it queries the repository default branch, otherwise it probes `origin/main` then `origin/master`
 - `/merge <branch>` requires a Git repository; if `gh` is installed it uses `gh pr merge --merge`, otherwise it uses `git merge`
-- `/checkout <branch|file>` requires a Git repository and runs `git checkout`; Tab completion offers branch names first, then workspace file paths
+- `/branch` requires a Git repository; with no arguments it lists local branches (`git branch`); `/branch -a` lists all branches including remote; `/branch <name>` switches to an existing branch; `/branch -b <name>` creates and switches to a new branch (`git checkout -b`); `/branch -m <new-name>` renames the current branch (`git branch -m`); `/branch -d <name>` deletes the branch (`git branch -D`), blocked on `main` and `master`; Tab completion after `/branch ` offers local branch names; `gh` has no equivalent so all operations always use plain Git
 - `/add_file <path>` requires a Git repository and runs `git add`; Tab completion offers untracked directories first, then untracked files
 - `/remove_file <path>` requires a Git repository and runs `git rm` (with `-r` for directories); Tab completion offers tracked directories first, then tracked files
 - `/move_file <source> <destination>` requires a Git repository and runs `git mv`; Tab completion for the first argument offers tracked directories first, then tracked files; Tab completion for the second argument offers workspace paths
+- `/restore [--staged] <file>` requires a Git repository and runs `git restore <file>` to discard working tree changes; with `--staged` it runs `git restore --staged <file>` to unstage the file; `gh` has no equivalent so it always uses plain Git
 - `/cherry_pick <commit>` requires a Git repository and runs `git cherry-pick`; `gh` has no equivalent so it always uses plain Git; Tab completion offers abbreviated commit hashes from the default branch (`origin/main`, `origin/master`, `main`, or `master`)
 - `/comment <number> "<comment>"` requires a Git repository and the `gh` CLI, and runs `gh issue comment <number> --body <comment>` to add a comment to a GitHub issue; without `gh` installed it reports an error since there is no plain Git equivalent; the comment text may be bare (`/comment 51 My comment`) or quoted (`/comment 51 "My comment"`); the natural-language form `add comment on 51 "My comment"` is also handled
 - `/commit <message>` requires a Git repository and runs `git commit -a -m <message>`; `gh` has no equivalent so it always uses plain Git; the message may be bare (`/commit Fix the bug`) or quoted (`/commit "[#42] My feature"`)
@@ -229,7 +230,6 @@ Free-form prompts are blocked when the server or model status in the header is r
 - `/squash` requires a Git repository; squashes all commits on the current branch (relative to `origin/main`, `origin/master`, `main`, or `master`, tried in that order) into a single commit using the oldest commit's message; `gh` has no equivalent so it always uses plain Git; squashing on `main` or `master` is blocked; requires at least two commits on the branch
 - `/stash` requires a Git repository and runs `git stash push` to save all uncommitted changes (both staged and unstaged) to the stash stack; `/stash pop` restores and removes the most recent stash entry with `git stash pop`; `/stash list` shows all stash entries with their index and description; `/stash drop` discards the most recent stash entry with `git stash drop`; `gh` has no stash equivalent so all four operations always use plain Git; running `/stash` with a clean working tree produces an error from Git
 - `/review` requires a Git repository; it opens a full-screen, two-pane review of the branch's changes (local plus committed) against the default branch — see the [review chapter](#review) for the full layout and key bindings; `gh` has no equivalent so it always uses plain Git
-- `/delete <branch>` requires a Git repository and runs `git branch -D`; `gh` has no equivalent so it always uses plain Git; deleting `main` or `master` is blocked; Tab completion offers local branch names excluding `main` and `master`
 - `/sessions [workspace]` lists all sessions found under `~/.orangu/sessions/`; output is one line per session with aligned columns: UUID, start date, last-updated date, command count, branch, and workspace path; sessions are sorted by creation time, most-recent first; an optional workspace argument filters the list to sessions whose workspace path contains the given string; the branch column shows `-` for sessions with no recorded branch
 - `/session [uuid]` prints the `orangu --resume <uuid>` command for the given session; Tab completion after `/session ` (with a trailing space) cycles through all session UUIDs, newest first; with no argument it lists all sessions (same as `/sessions`)
 - `/usage` shows session statistics: total application time, total time spent waiting for LLM responses, total tokens generated (counted with the bundled tokenizer), and average tokens per second
@@ -256,11 +256,16 @@ Local commands can also be entered in plain language. Examples:
 - `status` or `show status` or `git status`
 - `rebase` or `git rebase`
 - `merge feature/foo` or `git merge feature/foo`
-- `checkout main` or `checkout README.md` or `git checkout main`
-- `switch to main` or `switch to feature/foo` or `switch to main branch`
+- `branch` or `list branches` or `git branch`
+- `list all branches` or `branch -a`
+- `checkout main` or `git checkout main` or `switch to main` or `switch to main branch`
+- `create branch feature/x` or `new branch feature/x` or `branch -b feature/x`
+- `rename to new-name` or `rename branch to new-name`
+- `delete feature/foo` or `delete branch feature/foo` or `git branch -D feature/foo`
 - `add README.md` or `add file src/` or `git add README.md`
 - `remove README.md` or `remove file src/` or `git rm README.md`
 - `move old.rs new.rs` or `move file old.rs new.rs` or `git mv old.rs new.rs`
+- `restore README.md` or `git restore README.md`
 - `cherry pick abc1234` or `cherry-pick abc1234` or `git cherry-pick abc1234`
 - `commit "[#42] My feature"` or `commit Fix the bug` or `git commit -m "Fix the bug"`
 - `amend "[#42] My feature"` or `amend Fix the bug` or `git amend "[#42] My feature"` or `git commit --amend -m "Fix the bug"`
@@ -272,7 +277,6 @@ Local commands can also be entered in plain language. Examples:
 - `push` or `git push` or `git push origin`
 - `force push` or `push force` or `push --force`
 - `init` or `init repo` or `git init`
-- `delete feature/foo` or `delete branch feature/foo` or `git branch -D feature/foo`
 - `usage` or `show usage`
 - `session` or `switch session`
 
@@ -317,13 +321,13 @@ Completion cycling is reset as soon as you edit the line, move the cursor, paste
 
 The completion modes are checked in order:
 
-1. If the line starts with `/checkout `, or with the natural-language prefixes `checkout ` or `git checkout `, complete branch names first (from `git branch --all`), then workspace file paths. Branch names always appear before file names in the candidate list. If the line starts with the natural-language prefix `switch to `, complete branch names and tag names (from `git tag`), sorted together; workspace file paths are excluded.
+1. If the line starts with `/branch `, `/checkout `, or with the natural-language prefixes `checkout ` or `git checkout `, complete branch names first (from `git branch --all`), then workspace file paths. Branch names always appear before file names in the candidate list. If the line starts with the natural-language prefix `switch to `, complete branch names and tag names (from `git tag`), sorted together; workspace file paths are excluded.
 2. If the line starts with `/add_file `, or with the natural-language prefixes `add `, `add file `, or `git add `, complete untracked directories first (from `git ls-files --others --directory`), then untracked files. Already-tracked content is excluded.
 3. If the line starts with `/remove_file `, or with the natural-language prefixes `remove `, `remove file `, or `git rm `, complete tracked directories first (from `git ls-files`), then tracked files. Untracked content is excluded.
 4. If the line starts with `/move_file `, or with the natural-language prefixes `move `, `move file `, or `git mv `, complete the first argument from tracked directories and files; complete the second argument from all workspace paths.
 5. If the line starts with `/cherry_pick `, or with the natural-language prefixes `cherry pick `, `cherry-pick `, or `git cherry-pick `, complete abbreviated commit hashes from the default branch (`origin/main`, `origin/master`, `main`, or `master`, tried in that order).
 6. If the line starts with `/merge `, or with the natural-language prefixes `merge ` or `git merge `, complete local branch names first (from `git branch`), then remote-only branch names (from `git branch --all`).
-7. If the line starts with `/delete `, or with the natural-language prefixes `delete `, `delete branch `, or `git branch -D `, complete local branch names (from `git branch`) excluding `main` and `master`.
+7. If the line starts with `/branch -d `, or with the natural-language prefixes `delete `, `delete branch `, or `git branch -D `, complete local branch names (from `git branch`) excluding `main` and `master`.
 8. If the line starts with `/session ` (with a trailing space), complete session UUIDs sorted newest-first by last-modified time.
 9. If the line starts with `/model `, complete configured model profile names.
 10. If the line starts with `/open_file ` or `/show_file `, complete workspace file paths recursively for the first positional argument. `/show_file` also completes `--hash` and `--author`. When a file path is already present, the next Tab press cycles through that file's commit history (abbreviated hashes from `git log --follow`).

--- a/src/bin/orangu/commands.rs
+++ b/src/bin/orangu/commands.rs
@@ -132,6 +132,15 @@ pub enum StashSubcommand {
     Drop,
 }
 
+pub enum BranchSubcommand<'a> {
+    List,
+    ListAll,
+    Switch(Cow<'a, str>),
+    Create(Cow<'a, str>),
+    Rename(Cow<'a, str>),
+    Delete(Cow<'a, str>),
+}
+
 pub enum LocalCommand<'a> {
     Help,
     ConnectDefault,
@@ -153,7 +162,8 @@ pub enum LocalCommand<'a> {
     CreatePullRequest,
     Rebase,
     Merge(Option<Cow<'a, str>>),
-    Checkout(Option<Cow<'a, str>>),
+    Branch(BranchSubcommand<'a>),
+    Restore(Option<Cow<'a, str>>),
     AddFile(Option<Cow<'a, str>>),
     RemoveFile(Option<Cow<'a, str>>),
     MoveFile(Option<(Cow<'a, str>, Cow<'a, str>)>),
@@ -164,7 +174,6 @@ pub enum LocalCommand<'a> {
     InitRepo,
     Squash,
     Stash(StashSubcommand),
-    DeleteBranch(Option<Cow<'a, str>>),
     OpenFile(&'a str),
     Session(Option<Cow<'a, str>>),
     Sessions(Option<Cow<'a, str>>),
@@ -221,10 +230,10 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
         "/build" => Some(LocalCommand::Build),
         "/add_file" => Some(LocalCommand::AddFile(None)),
         "/amend" => Some(LocalCommand::Amend(None)),
-        "/checkout" => Some(LocalCommand::Checkout(None)),
+        "/branch" => Some(LocalCommand::Branch(BranchSubcommand::List)),
         "/cherry_pick" => Some(LocalCommand::CherryPick(None)),
         "/commit" => Some(LocalCommand::Commit(None)),
-        "/delete" => Some(LocalCommand::DeleteBranch(None)),
+        "/restore" => Some(LocalCommand::Restore(None)),
         "/diff" => Some(LocalCommand::Diff(None)),
         "/init_repo" => Some(LocalCommand::InitRepo),
         "/log" => Some(LocalCommand::Log),
@@ -293,11 +302,11 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
             }
             if let Some(args) = input.strip_prefix("/checkout ") {
                 let target = args.trim();
-                return Some(LocalCommand::Checkout(if target.is_empty() {
-                    None
-                } else {
-                    Some(Cow::Borrowed(target))
-                }));
+                if !target.is_empty() {
+                    return Some(LocalCommand::Branch(BranchSubcommand::Switch(
+                        Cow::Borrowed(target),
+                    )));
+                }
             }
             if let Some(args) = input.strip_prefix("/add_file ") {
                 let path = args.trim();
@@ -355,6 +364,56 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
                     return Some(LocalCommand::Push(true));
                 }
             }
+            if let Some(sub) = input.strip_prefix("/branch ") {
+                let sub = sub.trim();
+                return Some(LocalCommand::Branch(match sub {
+                    "-a" | "--all" => BranchSubcommand::ListAll,
+                    _ if sub.starts_with("-b ") => {
+                        let name = sub[3..].trim();
+                        if name.is_empty() {
+                            BranchSubcommand::List
+                        } else {
+                            BranchSubcommand::Create(Cow::Borrowed(name))
+                        }
+                    }
+                    _ if sub.starts_with("-m ") => {
+                        let name = sub[3..].trim();
+                        if name.is_empty() {
+                            BranchSubcommand::List
+                        } else {
+                            BranchSubcommand::Rename(Cow::Borrowed(name))
+                        }
+                    }
+                    _ if sub.starts_with("-d ") => {
+                        let name = sub[3..].trim();
+                        if name.is_empty() {
+                            BranchSubcommand::List
+                        } else {
+                            BranchSubcommand::Delete(Cow::Borrowed(name))
+                        }
+                    }
+                    _ if !sub.is_empty() => BranchSubcommand::Switch(Cow::Borrowed(sub)),
+                    _ => BranchSubcommand::List,
+                }));
+            }
+            if let Some(path) = input.strip_prefix("/restore ") {
+                let path = path.trim();
+                let staged = path.starts_with("--staged ") || path.starts_with("-S ");
+                let file = if staged {
+                    path.split_once(' ').map(|x| x.1).unwrap_or("").trim()
+                } else {
+                    path
+                };
+                return Some(LocalCommand::Restore(if file.is_empty() {
+                    None
+                } else {
+                    Some(Cow::Owned(format!(
+                        "{}{}",
+                        if staged { "--staged " } else { "" },
+                        file
+                    )))
+                }));
+            }
             if let Some(sub) = input.strip_prefix("/stash ") {
                 return Some(LocalCommand::Stash(match sub.trim() {
                     "pop" => StashSubcommand::Pop,
@@ -365,11 +424,11 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
             }
             if let Some(args) = input.strip_prefix("/delete ") {
                 let branch = args.trim();
-                return Some(LocalCommand::DeleteBranch(if branch.is_empty() {
-                    None
-                } else {
-                    Some(Cow::Borrowed(branch))
-                }));
+                if !branch.is_empty() {
+                    return Some(LocalCommand::Branch(BranchSubcommand::Delete(
+                        Cow::Borrowed(branch),
+                    )));
+                }
             }
             if let Some(args) = input.strip_prefix("/open_file ")
                 && args.trim().is_empty()
@@ -541,24 +600,59 @@ pub fn parse_natural_language_command(input: &str) -> Option<LocalCommand<'_>> {
     if matches_ci(input, &["merge"]) {
         return Some(LocalCommand::Merge(None));
     }
-    for prefix in ["git checkout ", "checkout "] {
+    for prefix in [
+        "git checkout ",
+        "checkout ",
+        "switch to branch ",
+        "switch to ",
+    ] {
         if let Some(target) = strip_ascii_prefix(input, prefix) {
-            let target = target.trim();
+            let target = strip_ascii_suffix(target.trim(), " branch")
+                .map(str::trim)
+                .unwrap_or(target.trim());
             if !target.is_empty() {
-                return Some(LocalCommand::Checkout(Some(Cow::Borrowed(target))));
+                return Some(LocalCommand::Branch(BranchSubcommand::Switch(
+                    Cow::Borrowed(target),
+                )));
             }
         }
     }
-    if let Some(target) = strip_ascii_prefix(input, "switch to ") {
-        let target = strip_ascii_suffix(target.trim(), " branch")
-            .map(str::trim)
-            .unwrap_or(target.trim());
-        if !target.is_empty() {
-            return Some(LocalCommand::Checkout(Some(Cow::Borrowed(target))));
+    for prefix in ["create branch ", "new branch ", "branch -b "] {
+        if let Some(name) = strip_ascii_prefix(input, prefix) {
+            let name = name.trim();
+            if !name.is_empty() {
+                return Some(LocalCommand::Branch(BranchSubcommand::Create(
+                    Cow::Borrowed(name),
+                )));
+            }
         }
     }
-    if matches_ci(input, &["checkout", "switch to"]) {
-        return Some(LocalCommand::Checkout(None));
+    for prefix in ["rename branch to ", "rename to ", "branch -m "] {
+        if let Some(name) = strip_ascii_prefix(input, prefix) {
+            let name = name.trim();
+            if !name.is_empty() {
+                return Some(LocalCommand::Branch(BranchSubcommand::Rename(
+                    Cow::Borrowed(name),
+                )));
+            }
+        }
+    }
+    if matches_ci(
+        input,
+        &["branch", "list branches", "git branch", "checkout"],
+    ) {
+        return Some(LocalCommand::Branch(BranchSubcommand::List));
+    }
+    if matches_ci(input, &["list all branches", "branch -a", "branch --all"]) {
+        return Some(LocalCommand::Branch(BranchSubcommand::ListAll));
+    }
+    for prefix in ["restore ", "git restore "] {
+        if let Some(path) = strip_ascii_prefix(input, prefix) {
+            let path = path.trim();
+            if !path.is_empty() {
+                return Some(LocalCommand::Restore(Some(Cow::Borrowed(path))));
+            }
+        }
     }
     for prefix in ["git add ", "add file ", "add "] {
         if let Some(path) = strip_ascii_prefix(input, prefix) {
@@ -665,13 +759,15 @@ pub fn parse_natural_language_command(input: &str) -> Option<LocalCommand<'_>> {
         return Some(LocalCommand::Squash);
     }
     if matches_ci(input, &["delete", "delete branch"]) {
-        return Some(LocalCommand::DeleteBranch(None));
+        return Some(LocalCommand::Branch(BranchSubcommand::List));
     }
     for prefix in ["git branch -D ", "delete branch ", "delete "] {
         if let Some(branch) = strip_ascii_prefix(input, prefix) {
             let branch = branch.trim();
             if !branch.is_empty() {
-                return Some(LocalCommand::DeleteBranch(Some(Cow::Borrowed(branch))));
+                return Some(LocalCommand::Branch(BranchSubcommand::Delete(
+                    Cow::Borrowed(branch),
+                )));
             }
         }
     }
@@ -911,8 +1007,8 @@ pub fn merge_usage_message() -> &'static str {
     "Usage: /merge <branch>. Use /help to see available commands."
 }
 
-pub fn checkout_usage_message() -> &'static str {
-    "Usage: /checkout <branch|file>. Use /help to see available commands."
+pub fn restore_usage_message() -> &'static str {
+    "Usage: /restore [--staged] <file>. Use /help to see available commands."
 }
 
 pub fn add_file_usage_message() -> &'static str {
@@ -937,10 +1033,6 @@ pub fn commit_usage_message() -> &'static str {
 
 pub fn amend_usage_message() -> &'static str {
     "Usage: /amend <message>. Use /help to see available commands."
-}
-
-pub fn delete_branch_usage_message() -> &'static str {
-    "Usage: /delete <branch>"
 }
 
 #[cfg(test)]
@@ -1280,75 +1372,85 @@ mod tests {
     }
 
     #[test]
-    fn parses_checkout_commands() {
+    fn parses_branch_commands() {
         assert!(matches!(
-            parse_local_command("/checkout"),
-            Some(LocalCommand::Checkout(None))
+            parse_local_command("/branch"),
+            Some(LocalCommand::Branch(BranchSubcommand::List))
         ));
         assert!(matches!(
-            parse_local_command("/checkout "),
-            Some(LocalCommand::Checkout(None))
+            parse_local_command("branch"),
+            Some(LocalCommand::Branch(BranchSubcommand::List))
+        ));
+        assert!(matches!(
+            parse_local_command("list branches"),
+            Some(LocalCommand::Branch(BranchSubcommand::List))
         ));
         assert!(matches!(
             parse_local_command("checkout"),
-            Some(LocalCommand::Checkout(None))
+            Some(LocalCommand::Branch(BranchSubcommand::List))
         ));
         assert!(matches!(
-            parse_local_command("Checkout"),
-            Some(LocalCommand::Checkout(None))
+            parse_local_command("/branch -a"),
+            Some(LocalCommand::Branch(BranchSubcommand::ListAll))
         ));
-        match parse_local_command("/checkout feature/foo") {
-            Some(LocalCommand::Checkout(Some(target))) => {
+        assert!(matches!(
+            parse_local_command("list all branches"),
+            Some(LocalCommand::Branch(BranchSubcommand::ListAll))
+        ));
+        match parse_local_command("/branch feature/foo") {
+            Some(LocalCommand::Branch(BranchSubcommand::Switch(target))) => {
                 assert_eq!(target.as_ref(), "feature/foo")
             }
-            _ => panic!("expected checkout with branch"),
+            _ => panic!("expected branch switch"),
+        }
+        match parse_local_command("/checkout feature/foo") {
+            Some(LocalCommand::Branch(BranchSubcommand::Switch(target))) => {
+                assert_eq!(target.as_ref(), "feature/foo")
+            }
+            _ => panic!("expected checkout alias switch"),
         }
         match parse_local_command("checkout feature/foo") {
-            Some(LocalCommand::Checkout(Some(target))) => {
+            Some(LocalCommand::Branch(BranchSubcommand::Switch(target))) => {
                 assert_eq!(target.as_ref(), "feature/foo")
             }
-            _ => panic!("expected natural checkout with branch"),
-        }
-        match parse_local_command("Checkout README.md") {
-            Some(LocalCommand::Checkout(Some(target))) => {
-                assert_eq!(target.as_ref(), "README.md")
-            }
-            _ => panic!("expected case-insensitive checkout with file"),
-        }
-        match parse_local_command("git checkout feature/foo") {
-            Some(LocalCommand::Checkout(Some(target))) => {
-                assert_eq!(target.as_ref(), "feature/foo")
-            }
-            _ => panic!("expected git checkout natural language"),
+            _ => panic!("expected natural checkout switch"),
         }
         match parse_local_command("switch to main") {
-            Some(LocalCommand::Checkout(Some(target))) => {
+            Some(LocalCommand::Branch(BranchSubcommand::Switch(target))) => {
                 assert_eq!(target.as_ref(), "main")
             }
             _ => panic!("expected switch to main"),
         }
-        match parse_local_command("Switch to main") {
-            Some(LocalCommand::Checkout(Some(target))) => {
-                assert_eq!(target.as_ref(), "main")
-            }
-            _ => panic!("expected case-insensitive switch to main"),
-        }
-        match parse_local_command("switch to feature/foo") {
-            Some(LocalCommand::Checkout(Some(target))) => {
-                assert_eq!(target.as_ref(), "feature/foo")
-            }
-            _ => panic!("expected switch to feature/foo"),
-        }
         match parse_local_command("switch to main branch") {
-            Some(LocalCommand::Checkout(Some(target))) => {
+            Some(LocalCommand::Branch(BranchSubcommand::Switch(target))) => {
                 assert_eq!(target.as_ref(), "main")
             }
             _ => panic!("expected switch to main branch -> main"),
         }
-        assert!(matches!(
-            parse_local_command("switch to"),
-            Some(LocalCommand::Checkout(None))
-        ));
+        match parse_local_command("/branch -b feature/new") {
+            Some(LocalCommand::Branch(BranchSubcommand::Create(name))) => {
+                assert_eq!(name.as_ref(), "feature/new")
+            }
+            _ => panic!("expected branch create"),
+        }
+        match parse_local_command("create branch feature/new") {
+            Some(LocalCommand::Branch(BranchSubcommand::Create(name))) => {
+                assert_eq!(name.as_ref(), "feature/new")
+            }
+            _ => panic!("expected NL branch create"),
+        }
+        match parse_local_command("/branch -m new-name") {
+            Some(LocalCommand::Branch(BranchSubcommand::Rename(name))) => {
+                assert_eq!(name.as_ref(), "new-name")
+            }
+            _ => panic!("expected branch rename"),
+        }
+        match parse_local_command("/branch -d feature/old") {
+            Some(LocalCommand::Branch(BranchSubcommand::Delete(name))) => {
+                assert_eq!(name.as_ref(), "feature/old")
+            }
+            _ => panic!("expected branch delete"),
+        }
     }
 
     #[test]
@@ -1710,40 +1812,36 @@ mod tests {
     #[test]
     fn parses_delete_branch_commands() {
         assert!(matches!(
-            parse_local_command("/delete feature/foo"),
-            Some(LocalCommand::DeleteBranch(Some(_)))
-        ));
-        assert!(matches!(
-            parse_local_command("/delete"),
-            Some(LocalCommand::DeleteBranch(None))
+            parse_local_command("/branch -d feature/foo"),
+            Some(LocalCommand::Branch(BranchSubcommand::Delete(_)))
         ));
         assert!(matches!(
             parse_local_command("delete feature/foo"),
-            Some(LocalCommand::DeleteBranch(Some(_)))
+            Some(LocalCommand::Branch(BranchSubcommand::Delete(_)))
         ));
         assert!(matches!(
             parse_local_command("Delete feature/foo"),
-            Some(LocalCommand::DeleteBranch(Some(_)))
+            Some(LocalCommand::Branch(BranchSubcommand::Delete(_)))
         ));
         assert!(matches!(
             parse_local_command("delete branch feature/foo"),
-            Some(LocalCommand::DeleteBranch(Some(_)))
+            Some(LocalCommand::Branch(BranchSubcommand::Delete(_)))
         ));
         assert!(matches!(
             parse_local_command("Delete Branch feature/foo"),
-            Some(LocalCommand::DeleteBranch(Some(_)))
+            Some(LocalCommand::Branch(BranchSubcommand::Delete(_)))
         ));
         assert!(matches!(
             parse_local_command("git branch -D feature/foo"),
-            Some(LocalCommand::DeleteBranch(Some(_)))
+            Some(LocalCommand::Branch(BranchSubcommand::Delete(_)))
         ));
         assert!(matches!(
             parse_local_command("delete branch"),
-            Some(LocalCommand::DeleteBranch(None))
+            Some(LocalCommand::Branch(BranchSubcommand::List))
         ));
         assert!(matches!(
             parse_local_command("delete"),
-            Some(LocalCommand::DeleteBranch(None))
+            Some(LocalCommand::Branch(BranchSubcommand::List))
         ));
     }
 

--- a/src/bin/orangu/completion.rs
+++ b/src/bin/orangu/completion.rs
@@ -41,7 +41,8 @@ pub const COMMANDS: &[&str] = &[
     "/comment",
     "/rebase",
     "/merge",
-    "/checkout",
+    "/branch",
+    "/restore",
     "/add_file",
     "/remove_file",
     "/move_file",
@@ -53,7 +54,6 @@ pub const COMMANDS: &[&str] = &[
     "/init_repo",
     "/squash",
     "/stash",
-    "/delete",
     "/open_file",
     "/session",
     "/sessions",
@@ -344,7 +344,9 @@ pub fn checkout_completion_candidates(
     prefix: &str,
     workspace: &Path,
 ) -> Option<(usize, Vec<String>)> {
-    let (start, token, switch_form) = if let Some(rest) = prefix.strip_prefix("/checkout ") {
+    let (start, token, switch_form) = if let Some(rest) = prefix.strip_prefix("/branch ") {
+        ("/branch ".len(), rest, false)
+    } else if let Some(rest) = prefix.strip_prefix("/checkout ") {
         ("/checkout ".len(), rest, false)
     } else if let Some(rest) = strip_ascii_prefix(prefix, "git checkout ") {
         (prefix.len() - rest.len(), rest, false)

--- a/src/bin/orangu/git.rs
+++ b/src/bin/orangu/git.rs
@@ -1493,19 +1493,6 @@ pub fn git_merge(repo_root: &Path, branch: &str) -> Result<String> {
     })
 }
 
-pub fn checkout_output(workspace: &Path, target: &str) -> Result<String> {
-    let repo_root = discover_git_root(workspace)
-        .ok_or_else(|| anyhow!("checkout is only available inside a Git repository"))?;
-    if let Some(output) = try_gh_checkout(&repo_root, target)? {
-        return Ok(output);
-    }
-    git_checkout(&repo_root, target)
-}
-
-pub fn try_gh_checkout(_repo_root: &Path, _target: &str) -> Result<Option<String>> {
-    Ok(None)
-}
-
 pub fn git_checkout(repo_root: &Path, target: &str) -> Result<String> {
     let output = std::process::Command::new("git")
         .arg("-C")
@@ -2021,49 +2008,6 @@ pub fn git_find_base_ref(repo_root: &Path) -> Result<String> {
     ))
 }
 
-pub fn delete_branch_output(workspace: &Path, branch: &str) -> Result<String> {
-    let repo_root = discover_git_root(workspace)
-        .ok_or_else(|| anyhow!("delete is only available inside a Git repository"))?;
-    if is_protected_branch(branch) {
-        return Err(anyhow!("deleting the '{}' branch is not allowed", branch));
-    }
-    if let Some(output) = try_gh_delete_branch(&repo_root, branch)? {
-        return Ok(output);
-    }
-    git_delete_branch(&repo_root, branch)
-}
-
-pub fn try_gh_delete_branch(_repo_root: &Path, _branch: &str) -> Result<Option<String>> {
-    Ok(None)
-}
-
-pub fn git_delete_branch(repo_root: &Path, branch: &str) -> Result<String> {
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(repo_root)
-        .args(["branch", "-D", branch])
-        .output()
-        .context("failed to run git branch -D")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let detail = [stdout, stderr]
-            .into_iter()
-            .filter(|s| !s.is_empty())
-            .collect::<Vec<_>>()
-            .join("\n");
-        return Err(anyhow!(
-            "git branch -D failed{}",
-            if detail.is_empty() {
-                String::new()
-            } else {
-                format!(": {detail}")
-            }
-        ));
-    }
-    Ok(format!("Deleted branch '{branch}'"))
-}
-
 pub fn stash_output(workspace: &Path) -> Result<String> {
     let repo_root = discover_git_root(workspace)
         .ok_or_else(|| anyhow!("stash is only available inside a Git repository"))?;
@@ -2173,6 +2117,177 @@ pub fn stash_drop_output(workspace: &Path) -> Result<String> {
         "Stash dropped".to_string()
     } else {
         stdout
+    })
+}
+
+pub fn branch_list_output(workspace: &Path) -> Result<String> {
+    let repo_root = discover_git_root(workspace)
+        .ok_or_else(|| anyhow!("branch is only available inside a Git repository"))?;
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_root)
+        .args(["branch"])
+        .output()
+        .context("failed to run git branch")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!(
+            "git branch failed{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(if stdout.is_empty() {
+        "No local branches found".to_string()
+    } else {
+        stdout
+    })
+}
+
+pub fn branch_list_all_output(workspace: &Path) -> Result<String> {
+    let repo_root = discover_git_root(workspace)
+        .ok_or_else(|| anyhow!("branch is only available inside a Git repository"))?;
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_root)
+        .args(["branch", "-a"])
+        .output()
+        .context("failed to run git branch -a")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!(
+            "git branch -a failed{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(if stdout.is_empty() {
+        "No branches found".to_string()
+    } else {
+        stdout
+    })
+}
+
+pub fn branch_create_output(workspace: &Path, name: &str) -> Result<String> {
+    let repo_root = discover_git_root(workspace)
+        .ok_or_else(|| anyhow!("branch is only available inside a Git repository"))?;
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_root)
+        .args(["checkout", "-b", name])
+        .output()
+        .context("failed to run git checkout -b")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!(
+            "git checkout -b failed{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    Ok(if stderr.is_empty() {
+        format!("Switched to a new branch '{name}'")
+    } else {
+        stderr
+    })
+}
+
+pub fn branch_rename_output(workspace: &Path, new_name: &str) -> Result<String> {
+    let repo_root = discover_git_root(workspace)
+        .ok_or_else(|| anyhow!("branch is only available inside a Git repository"))?;
+    let current = git_current_branch(&repo_root)?;
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_root)
+        .args(["branch", "-m", new_name])
+        .output()
+        .context("failed to run git branch -m")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!(
+            "git branch -m failed{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    Ok(format!("Renamed branch '{current}' to '{new_name}'"))
+}
+
+pub fn branch_delete_output(workspace: &Path, name: &str) -> Result<String> {
+    let repo_root = discover_git_root(workspace)
+        .ok_or_else(|| anyhow!("branch is only available inside a Git repository"))?;
+    if is_protected_branch(name) {
+        return Err(anyhow!("deleting the '{}' branch is not allowed", name));
+    }
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_root)
+        .args(["branch", "-D", name])
+        .output()
+        .context("failed to run git branch -D")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!(
+            "git branch -D failed{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(if stdout.is_empty() {
+        format!("Deleted branch '{name}'")
+    } else {
+        stdout
+    })
+}
+
+pub fn restore_output(workspace: &Path, path: &str, staged: bool) -> Result<String> {
+    let repo_root = discover_git_root(workspace)
+        .ok_or_else(|| anyhow!("restore is only available inside a Git repository"))?;
+    let args: &[&str] = if staged {
+        &["restore", "--staged", path]
+    } else {
+        &["restore", path]
+    };
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_root)
+        .args(args)
+        .output()
+        .context("failed to run git restore")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!(
+            "git restore failed{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    Ok(if staged {
+        format!("Unstaged '{path}'")
+    } else {
+        format!("Restored '{path}'")
     })
 }
 
@@ -2298,7 +2413,7 @@ mod tests {
             .output()
             .expect("git init");
         for branch in ["main", "master"] {
-            let result = delete_branch_output(workspace.path(), branch);
+            let result = branch_delete_output(workspace.path(), branch);
             assert!(result.is_err(), "should block deletion of '{branch}'");
             let msg = result.unwrap_err().to_string();
             assert!(

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -57,21 +57,22 @@ use uuid::Uuid;
 use anyhow::Error;
 use commands::ReviewLaunch;
 use commands::{
-    CommandContext, CommandOutcome, CommandState, LocalCommand, LocalError, StashSubcommand,
-    add_file_usage_message, amend_usage_message, checkout_usage_message, cherry_pick_usage_message,
-    comment_usage_message, commit_usage_message, connect_usage_message,
-    delete_branch_usage_message, merge_usage_message, model_usage_message, move_file_usage_message,
-    open_file_usage_message, parse_local_command, pull_usage_message, remove_file_usage_message,
-    sorted_model_names, system_prompt,
+    BranchSubcommand, CommandContext, CommandOutcome, CommandState, LocalCommand, LocalError,
+    StashSubcommand, add_file_usage_message, amend_usage_message, cherry_pick_usage_message,
+    comment_usage_message, commit_usage_message, connect_usage_message, merge_usage_message,
+    model_usage_message, move_file_usage_message, open_file_usage_message, parse_local_command,
+    pull_usage_message, remove_file_usage_message, restore_usage_message, sorted_model_names,
+    system_prompt,
 };
 use git::{
-    Forge, add_file_output, amend_output, checkout_output, cherry_pick_output, collect_review_diff,
-    comment_output, commit_output, create_pull_request_output, delete_branch_output,
-    discover_git_root, git_diff_against_branch, git_workspace_diff, init_repo_output,
+    Forge, add_file_output, amend_output, branch_create_output, branch_delete_output,
+    branch_list_all_output, branch_list_output, branch_rename_output, cherry_pick_output,
+    collect_review_diff, comment_output, commit_output, create_pull_request_output,
+    discover_git_root, git_checkout, git_diff_against_branch, git_workspace_diff, init_repo_output,
     list_workspace_files_tree, log_output, merge_output, move_file_output, open_in_editor,
-    pull_request_output, push_output, rebase_output, remove_file_output, squash_output,
-    stash_drop_output, stash_list_output, stash_output, stash_pop_output, status_output,
-    sync_default_branch, workspace_branch_name,
+    pull_request_output, push_output, rebase_output, remove_file_output, restore_output,
+    squash_output, stash_drop_output, stash_list_output, stash_output, stash_pop_output,
+    status_output, sync_default_branch, workspace_branch_name,
 };
 use input::{
     EscapeCancelState, IDLE_STATUS_REFRESH_INTERVAL, InputContext, InputResult, InputState,
@@ -1145,13 +1146,61 @@ fn handle_command(
             Ok(_) => Ok(CommandOutcome::Quiet),
             Err(err) => Ok(local_command_error(err)),
         },
-        LocalCommand::Checkout(None) => Ok(CommandOutcome::OutputError(
-            checkout_usage_message().to_string(),
-        )),
-        LocalCommand::Checkout(Some(target)) => match checkout_output(workspace, &target) {
-            Ok(_) => Ok(CommandOutcome::Quiet),
-            Err(err) => Ok(local_command_error(err)),
+        LocalCommand::Branch(sub) => match sub {
+            BranchSubcommand::List => match branch_list_output(workspace) {
+                Ok(output) => Ok(CommandOutcome::Output(output)),
+                Err(err) => Ok(local_command_error(err)),
+            },
+            BranchSubcommand::ListAll => match branch_list_all_output(workspace) {
+                Ok(output) => Ok(CommandOutcome::Output(output)),
+                Err(err) => Ok(local_command_error(err)),
+            },
+            BranchSubcommand::Switch(name) => {
+                let root = match discover_git_root(workspace) {
+                    Some(r) => r,
+                    None => {
+                        return Ok(local_command_error(anyhow::anyhow!(
+                            "branch is only available inside a Git repository"
+                        )));
+                    }
+                };
+                match git_checkout(&root, &name) {
+                    Ok(_) => Ok(CommandOutcome::Quiet),
+                    Err(err) => Ok(local_command_error(err)),
+                }
+            }
+            BranchSubcommand::Create(name) => match branch_create_output(workspace, &name) {
+                Ok(_) => Ok(CommandOutcome::Quiet),
+                Err(err) => Ok(local_command_error(err)),
+            },
+            BranchSubcommand::Rename(name) => match branch_rename_output(workspace, &name) {
+                Ok(output) => Ok(CommandOutcome::Output(output)),
+                Err(err) => Ok(local_command_error(err)),
+            },
+            BranchSubcommand::Delete(name) => match branch_delete_output(workspace, &name) {
+                Ok(_) => Ok(CommandOutcome::Quiet),
+                Err(err) => Ok(local_command_error(err)),
+            },
         },
+        LocalCommand::Restore(None) => Ok(CommandOutcome::OutputError(
+            restore_usage_message().to_string(),
+        )),
+        LocalCommand::Restore(Some(arg)) => {
+            let staged = arg.starts_with("--staged ");
+            let path = if staged {
+                arg.split_once(' ')
+                    .map(|x| x.1)
+                    .unwrap_or("")
+                    .trim()
+                    .to_string()
+            } else {
+                arg.to_string()
+            };
+            match restore_output(workspace, &path, staged) {
+                Ok(_) => Ok(CommandOutcome::Quiet),
+                Err(err) => Ok(local_command_error(err)),
+            }
+        }
         LocalCommand::AddFile(None) => Ok(CommandOutcome::OutputError(
             add_file_usage_message().to_string(),
         )),
@@ -1214,15 +1263,6 @@ fn handle_command(
                 StashSubcommand::List => stash_list_output(&ws),
                 StashSubcommand::Drop => stash_drop_output(&ws),
             })))
-        }
-        LocalCommand::DeleteBranch(None) => Ok(CommandOutcome::OutputError(
-            delete_branch_usage_message().to_string(),
-        )),
-        LocalCommand::DeleteBranch(Some(branch)) => {
-            match delete_branch_output(workspace, &branch) {
-                Ok(_) => Ok(CommandOutcome::Quiet),
-                Err(err) => Ok(local_command_error(err)),
-            }
         }
         LocalCommand::OpenFile(path) => {
             if path.is_empty() {
@@ -2816,7 +2856,7 @@ mod tests {
     use super::completion::completion_candidates;
     use super::git::with_explicit_pager_width;
     use super::git::{
-        delete_branch_output, discover_git_dir, discover_git_root, git_workspace_diff,
+        branch_delete_output, discover_git_dir, discover_git_root, git_workspace_diff,
         init_repo_output, is_protected_branch, list_workspace_files_tree, workspace_branch_name,
     };
     use super::input::idle_status_refresh_timeout;
@@ -3813,7 +3853,7 @@ mod tests {
             .output()
             .expect("git init");
         for branch in ["main", "master"] {
-            let result = delete_branch_output(workspace.path(), branch);
+            let result = branch_delete_output(workspace.path(), branch);
             assert!(result.is_err(), "should block deletion of '{branch}'");
             let msg = result.unwrap_err().to_string();
             assert!(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -185,11 +185,10 @@ pub fn help_text() -> &'static str {
 /build                                        Build the project
 /add_file <path>                              Stage a file or directory with git add
 /amend <message>                              Rewrite the last commit message with git commit --amend
-/checkout <branch|file>                       Switch branch or restore a file
+/branch [<name>|-a|-b|-m|-d <name>]           List, switch, create, rename or delete a branch
 /cherry_pick <commit>                         Cherry-pick a commit onto the current branch
 /comment <number> "<comment>"                 Add a comment to a GitHub/GitLab issue with gh/glab
 /commit <message>                             Commit all tracked changes with git commit -a -m
-/delete <branch>                              Delete a local branch with git branch -D
 /diff                                         Show a color unified diff against the current branch
 /init_repo                                    Initialize a Git repository in the workspace
 /log                                          Show commit log (uses git lg alias if configured)
@@ -200,6 +199,7 @@ pub fn help_text() -> &'static str {
 /push [--force]                               Push the current branch to origin
 /rebase                                       Rebase the current branch against master/main
 /remove_file <path>                           Remove a file or directory from Git tracking
+/restore [--staged] <file>                    Restore a file or unstage it (git restore)
 /review                                       Review branch changes against main/master in a split view
 /squash                                       Squash all branch commits into one
 /stash                                        Save uncommitted changes (git stash push)
@@ -211,7 +211,7 @@ pub fn help_text() -> &'static str {
 /clear                                        Clear the current conversation
 /quit                                         Exit the client
 
-Natural-language forms such as `open README.md`, `list models`, `list files`, `pull 58`, `log`, `status`, `rebase`, `squash`, `merge feature/foo`, `checkout main`, `add README.md`, `remove README.md`, `move old.rs new.rs`, `cherry pick abc1234`, `commit "[#42] My feature"`, `amend "[#42] My feature"`, `push`, `force push`, `add comment on 51 "My comment"`, `review`, `create pull request`, `stash`, `stash pop`, `stash list`, `stash drop`, `init repo`, `delete feature/foo`, and `show help` are also handled locally.
+Natural-language forms such as `open README.md`, `list models`, `list files`, `pull 58`, `log`, `status`, `rebase`, `squash`, `merge feature/foo`, `branch`, `list branches`, `checkout main`, `switch to main`, `create branch feature/x`, `rename to new-name`, `delete feature/foo`, `restore README.md`, `add README.md`, `remove README.md`, `move old.rs new.rs`, `cherry pick abc1234`, `commit "[#42] My feature"`, `amend "[#42] My feature"`, `push`, `force push`, `add comment on 51 "My comment"`, `review`, `create pull request`, `stash`, `stash pop`, `stash list`, `stash drop`, `init repo`, and `show help` are also handled locally.
 
 The prompt uses standard Unix shell keys, including Ctrl+Left, Ctrl+Right, Ctrl+A, Ctrl+E, Ctrl+K, Ctrl+U, Ctrl+W, Alt+Backspace, Alt+D, and Tab completion.
 
@@ -1192,7 +1192,8 @@ impl OranguHelper {
                 "/pull".to_string(),
                 "/rebase".to_string(),
                 "/merge".to_string(),
-                "/checkout".to_string(),
+                "/branch".to_string(),
+                "/restore".to_string(),
                 "/add_file".to_string(),
                 "/remove_file".to_string(),
                 "/move_file".to_string(),
@@ -1202,7 +1203,6 @@ impl OranguHelper {
                 "/push".to_string(),
                 "/init_repo".to_string(),
                 "/squash".to_string(),
-                "/delete".to_string(),
                 "/clear".to_string(),
                 "/quit".to_string(),
             ],


### PR DESCRIPTION
- /branch replaces /checkout and /delete as the single branch command:
  - /branch          list local branches (git branch)
  - /branch -a       list all branches including remote
  - /branch <name>   switch to existing branch
  - /branch -b <name> create and switch to new branch (git checkout -b)
  - /branch -m <name> rename the current branch (git branch -m)
  - /branch -d <name> delete branch (git branch -D), blocked on main/master
- /restore [--staged] <file> replaces /checkout for file restoration:
  - /restore <file>          discard working tree changes (git restore)
  - /restore --staged <file> unstage a file (git restore --staged)
- /checkout and /delete removed; NL shortcuts (switch to, delete, rename, checkout) route to /branch
- Tab completion updated: /branch triggers branch-name completion
- Documented in 40-terminal.md: table, command notes, NL alias list, completion section