### PR TITLE
[#71] /grep: Search the workspace with git grep

### DIFF
--- a/doc/manual/en/40-terminal.md
+++ b/doc/manual/en/40-terminal.md
@@ -179,6 +179,7 @@ All slash commands are handled locally. They are not sent to the model.
 | `/comment <number> "<comment>"` | Add a comment to a GitHub issue with gh issue comment |
 | `/commit <message>` | Commit all tracked changes with git commit -a -m |
 | `/diff [branch]` | Show a color unified diff; without a branch shows unstaged changes, with a branch shows changes since diverging from it |
+| `/grep <pattern>` | Search the workspace for a pattern with git grep |
 | `/init_repo` | Initialize a Git repository in the workspace |
 | `/log` | Show commit log (uses `git lg` alias if configured) |
 | `/merge <branch>` | Merge a branch into the current branch |
@@ -210,6 +211,7 @@ Free-form prompts are blocked when the server or model status in the header is r
 - `/open_file <path>` is workspace-scoped; paths outside the workspace are rejected. It launches `$EDITOR` on the file in a separate window so orangu stays usable, and never waits for the editor.
 - `/show_file [--hash] [--author] <path> [<ref>]` is workspace-scoped; without a ref, the current workspace file is shown — when `bat` is installed it is used for the plain view, otherwise the built-in syntax-highlighted renderer is used; when a ref (commit hash, branch, or tag) is given, the file content at that ref is retrieved via `git show <ref>:<path>` and rendered with the built-in renderer; `--hash` and `--author` add per-line blame columns sourced from `git blame`, using the same ref when one is provided; Tab completion for the first positional argument offers workspace file paths recursively; Tab completion for the second positional argument cycles through that file's commit history (abbreviated hashes from `git log --follow`)
 - `/build` detects the project type from the workspace root and runs the appropriate toolchain: for Rust (`Cargo.toml`) it runs `cargo fmt`, `cargo clippy`, `cargo build`, and `cargo test`; for C (`CMakeLists.txt`) it runs `clang-format.sh` (if present), creates a `build/` directory if needed, runs `cmake ..` on the first build, then `make`; for Java (`pom.xml`) it installs frontend dependencies with `npm ci` when outdated, runs `npm run fix` and `npm run check` for the frontend (if `src/frontend/` exists), then `mvn package`; each step is reported individually and the pipeline stops on first failure
+- `/grep <pattern>` requires a Git repository and runs `git grep <pattern>` to search all tracked files; output is piped through the configured non-interactive pager (`pager.grep`, then `core.pager`) when one is set — if `delta` is configured it will colorize and format the results; exit code 1 (no matches) is handled gracefully; `gh` has no equivalent so it always uses plain Git; natural-language forms `grep <pattern>` and `find <pattern>` are also handled
 - `/diff` uses `git diff` inside Git repositories and applies configured non-interactive Git pagers such as `delta`; outside Git repositories it keeps the existing non-Git behavior; `/diff <branch>` runs `git diff <branch>...HEAD` to show commits on the current branch not yet in the specified branch; Tab completion after `/diff ` or natural-language forms such as `diff against <branch>` offers local and remote branch names
 - `/status` requires a Git repository and runs `git status --branch --short`; `gh` has no equivalent so it always uses plain Git; added files and untracked entries are shown in green, deleted entries in red, and modified entries in the default terminal color; the branch line is shown in a muted color
 - `/log` requires a Git repository; if a `lg` alias is found in `~/.gitconfig` it runs `git lg`, otherwise it falls back to `git log --graph --oneline --decorate`; see the optional tools chapter for the recommended `git lg` alias setup
@@ -256,6 +258,7 @@ Local commands can also be entered in plain language. Examples:
 - `review` or `review changes` or `code review` or `review branch`
 - `log` or `show log` or `git log` or `git lg`
 - `status` or `show status` or `git status`
+- `grep <pattern>` or `find <pattern>` or `git grep <pattern>`
 - `rebase` or `git rebase`
 - `merge feature/foo` or `git merge feature/foo`
 - `branch` or `list branches` or `git branch`

--- a/src/bin/orangu/commands.rs
+++ b/src/bin/orangu/commands.rs
@@ -156,6 +156,7 @@ pub enum LocalCommand<'a> {
     ModelInfo,
     SetModel(&'a str),
     Diff(Option<Cow<'a, str>>),
+    Grep(Option<Cow<'a, str>>),
     Review,
     Status,
     Log,
@@ -238,6 +239,7 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
         "/commit" => Some(LocalCommand::Commit(None)),
         "/restore" => Some(LocalCommand::Restore(None)),
         "/diff" => Some(LocalCommand::Diff(None)),
+        "/grep" => Some(LocalCommand::Grep(None)),
         "/init_repo" => Some(LocalCommand::InitRepo),
         "/log" => Some(LocalCommand::Log),
         "/merge" => Some(LocalCommand::Merge(None)),
@@ -281,6 +283,14 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
                     None
                 } else {
                     Some(Cow::Borrowed(branch))
+                }));
+            }
+            if let Some(args) = input.strip_prefix("/grep ") {
+                let pattern = args.trim();
+                return Some(LocalCommand::Grep(if pattern.is_empty() {
+                    None
+                } else {
+                    Some(Cow::Borrowed(pattern))
                 }));
             }
             if let Some(name) = input.strip_prefix("/model ") {
@@ -533,6 +543,14 @@ pub fn parse_natural_language_command(input: &str) -> Option<LocalCommand<'_>> {
     }
     if matches_ci(input, &["status", "show status", "git status"]) {
         return Some(LocalCommand::Status);
+    }
+    for prefix in ["grep ", "find ", "git grep "] {
+        if let Some(pattern) = strip_ascii_prefix(input, prefix) {
+            let pattern = pattern.trim();
+            if !pattern.is_empty() {
+                return Some(LocalCommand::Grep(Some(Cow::Borrowed(pattern))));
+            }
+        }
     }
     if matches_ci(input, &["log", "show log", "git log", "git lg"]) {
         return Some(LocalCommand::Log);
@@ -1015,6 +1033,10 @@ pub fn merge_usage_message() -> &'static str {
 
 pub fn restore_usage_message() -> &'static str {
     "Usage: /restore [--staged] <file>. Use /help to see available commands."
+}
+
+pub fn grep_usage_message() -> &'static str {
+    "Usage: /grep <pattern>. Use /help to see available commands."
 }
 
 pub fn add_file_usage_message() -> &'static str {

--- a/src/bin/orangu/completion.rs
+++ b/src/bin/orangu/completion.rs
@@ -35,6 +35,7 @@ pub const COMMANDS: &[&str] = &[
     "/tools",
     "/model",
     "/diff",
+    "/grep",
     "/review",
     "/status",
     "/log",

--- a/src/bin/orangu/git.rs
+++ b/src/bin/orangu/git.rs
@@ -625,8 +625,13 @@ fn run_git_diff_capture(repo_root: &Path, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-pub fn configured_git_diff_pager(repo_root: &Path) -> Result<Option<String>> {
-    for key in ["pager.diff", "core.pager"] {
+/// Look up the non-interactive pager configured for a specific git subcommand.
+/// Checks `pager.<subcommand>` first, then falls back to `core.pager`.
+/// Returns `None` when no pager is configured or the configured pager is an
+/// interactive one (less, more, …) that cannot be used non-interactively.
+pub fn configured_git_pager(repo_root: &Path, subcommand: &str) -> Result<Option<String>> {
+    let pager_key = format!("pager.{subcommand}");
+    for key in [pager_key.as_str(), "core.pager"] {
         let output = std::process::Command::new("git")
             .arg("-C")
             .arg(repo_root)
@@ -644,8 +649,11 @@ pub fn configured_git_diff_pager(repo_root: &Path) -> Result<Option<String>> {
         }
         return Ok(Some(value.to_string()));
     }
-
     Ok(None)
+}
+
+pub fn configured_git_diff_pager(repo_root: &Path) -> Result<Option<String>> {
+    configured_git_pager(repo_root, "diff")
 }
 
 pub fn looks_like_interactive_pager(command: &str) -> bool {
@@ -690,7 +698,7 @@ pub fn run_git_diff_pager(
 ) -> Result<String> {
     let pager_command = with_explicit_pager_width(pager_command, terminal_width);
     let mut pager = std::process::Command::new("sh")
-        .arg("-lc")
+        .arg("-c")
         .arg(&pager_command)
         .current_dir(repo_root)
         .env("COLUMNS", terminal_width.to_string())
@@ -722,6 +730,38 @@ pub fn run_git_diff_pager(
     }
 
     String::from_utf8(output.stdout).context("git pager output was not UTF-8")
+}
+
+pub fn grep_output(workspace: &Path, pattern: &str) -> Result<String> {
+    let repo_root = discover_git_root(workspace)
+        .ok_or_else(|| anyhow!("grep is only available inside a Git repository"))?;
+    let terminal_width = current_terminal_width();
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_root)
+        .args(["grep", pattern])
+        .env("COLUMNS", terminal_width.to_string())
+        .output()
+        .context("failed to run git grep")?;
+    if output.status.code() == Some(1) {
+        return Ok(format!("No matches for '{pattern}'."));
+    }
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!(
+            "git grep failed{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        ));
+    }
+    if let Some(pager_command) = configured_git_pager(&repo_root, "grep")? {
+        run_git_diff_pager(&repo_root, &pager_command, &output.stdout, terminal_width)
+    } else {
+        String::from_utf8(output.stdout).context("git grep output was not UTF-8")
+    }
 }
 
 pub fn status_output(workspace: &Path) -> Result<String> {

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -59,20 +59,20 @@ use commands::ReviewLaunch;
 use commands::{
     BranchSubcommand, CommandContext, CommandOutcome, CommandState, LocalCommand, LocalError,
     StashSubcommand, add_file_usage_message, amend_usage_message, cherry_pick_usage_message,
-    comment_usage_message, commit_usage_message, connect_usage_message, merge_usage_message,
-    model_usage_message, move_file_usage_message, open_file_usage_message, parse_local_command,
-    pull_usage_message, remove_file_usage_message, restore_usage_message, sorted_model_names,
-    system_prompt,
+    comment_usage_message, commit_usage_message, connect_usage_message, grep_usage_message,
+    merge_usage_message, model_usage_message, move_file_usage_message, open_file_usage_message,
+    parse_local_command, pull_usage_message, remove_file_usage_message, restore_usage_message,
+    sorted_model_names, system_prompt,
 };
 use git::{
     Forge, add_file_output, amend_output, branch_create_output, branch_delete_output,
     branch_list_all_output, branch_list_output, branch_rename_output, cherry_pick_output,
     collect_review_diff, comment_output, commit_output, create_pull_request_output,
-    discover_git_root, git_checkout, git_diff_against_branch, git_workspace_diff, init_repo_output,
-    list_workspace_files_tree, log_output, merge_output, move_file_output, open_in_editor,
-    pull_request_output, push_output, rebase_output, remove_file_output, restore_output,
-    squash_output, stash_drop_output, stash_list_output, stash_output, stash_pop_output,
-    status_output, sync_default_branch, workspace_branch_name,
+    discover_git_root, git_checkout, git_diff_against_branch, git_workspace_diff, grep_output,
+    init_repo_output, list_workspace_files_tree, log_output, merge_output, move_file_output,
+    open_in_editor, pull_request_output, push_output, rebase_output, remove_file_output,
+    restore_output, squash_output, stash_drop_output, stash_list_output, stash_output,
+    stash_pop_output, status_output, sync_default_branch, workspace_branch_name,
 };
 use input::{
     EscapeCancelState, IDLE_STATUS_REFRESH_INTERVAL, InputContext, InputResult, InputState,
@@ -1143,6 +1143,13 @@ fn handle_command(
             Err(err) => Ok(local_command_error(err)),
         },
         LocalCommand::Status => match status_output(workspace) {
+            Ok(output) => Ok(CommandOutcome::Output(output)),
+            Err(err) => Ok(local_command_error(err)),
+        },
+        LocalCommand::Grep(None) => Ok(CommandOutcome::OutputError(
+            grep_usage_message().to_string(),
+        )),
+        LocalCommand::Grep(Some(pattern)) => match grep_output(workspace, &pattern) {
             Ok(output) => Ok(CommandOutcome::Output(output)),
             Err(err) => Ok(local_command_error(err)),
         },
@@ -4006,7 +4013,7 @@ mod tests {
     }
 
     // The pager test requires `sh` in PATH and a POSIX shell script as the pager.
-    // `run_git_diff_pager` invokes `sh -lc`, which is not guaranteed to be in PATH
+    // `run_git_diff_pager` invokes `sh -c`, which is not guaranteed to be in PATH
     // on Windows (Git for Windows may not add its bundled sh.exe to PATH).
     #[cfg(not(windows))]
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -191,6 +191,7 @@ pub fn help_text() -> &'static str {
 /comment <number> "<comment>"                 Add a comment to a GitHub/GitLab issue with gh/glab
 /commit <message>                             Commit all tracked changes with git commit -a -m
 /diff                                         Show a color unified diff against the current branch
+/grep <pattern>                               Search the workspace with git grep
 /init_repo                                    Initialize a Git repository in the workspace
 /log                                          Show commit log (uses git lg alias if configured)
 /merge <branch>                               Merge a branch into the current branch
@@ -212,7 +213,7 @@ pub fn help_text() -> &'static str {
 /clear                                        Clear the current conversation
 /quit                                         Exit the client
 
-Natural-language forms such as `open README.md`, `list models`, `list files`, `pull 58`, `log`, `status`, `rebase`, `squash`, `merge feature/foo`, `branch`, `list branches`, `checkout main`, `switch to main`, `create branch feature/x`, `rename to new-name`, `delete feature/foo`, `restore README.md`, `add README.md`, `remove README.md`, `move old.rs new.rs`, `cherry pick abc1234`, `commit "[#42] My feature"`, `amend "[#42] My feature"`, `push`, `force push`, `add comment on 51 "My comment"`, `review`, `create pull request`, `stash`, `stash pop`, `stash list`, `stash drop`, `init repo`, `restart`, and `show help` are also handled locally.
+Natural-language forms such as `open README.md`, `list models`, `list files`, `pull 58`, `log`, `status`, `rebase`, `squash`, `merge feature/foo`, `grep <pattern>`, `find <pattern>`, `branch`, `list branches`, `checkout main`, `switch to main`, `create branch feature/x`, `rename to new-name`, `delete feature/foo`, `restore README.md`, `add README.md`, `remove README.md`, `move old.rs new.rs`, `cherry pick abc1234`, `commit "[#42] My feature"`, `amend "[#42] My feature"`, `push`, `force push`, `add comment on 51 "My comment"`, `review`, `create pull request`, `stash`, `stash pop`, `stash list`, `stash drop`, `init repo`, `restart`, and `show help` are also handled locally.
 
 The prompt uses standard Unix shell keys, including Ctrl+Left, Ctrl+Right, Ctrl+A, Ctrl+E, Ctrl+K, Ctrl+U, Ctrl+W, Alt+Backspace, Alt+D, and Tab completion.
 


### PR DESCRIPTION
Closes #71

Adds a `/grep <pattern>` command that searches all tracked files in the workspace using `git grep --line-number`.

**New `/grep` command:**
- `/grep <pattern>` — search tracked files for a pattern
- Natural-language: `grep <pattern>`, `find <pattern>`, `git grep <pattern>`
- Gracefully handles exit code 1 (no matches) with a friendly message
- Requires a Git repository; always uses plain Git (`gh` has no equivalent)

**Files changed:**
- `commands.rs` — `Grep` variant, slash + NL parsers, usage message
- `git.rs` — `grep_output` function
- `main.rs` — dispatch handler
- `tui.rs` — help text + NL forms sentence
- `completion.rs` — added `/grep` to command list
- `40-terminal.md` — command table, command notes, NL aliases
