### PR TITLE
[#85] tool: /prune

### DIFF
--- a/doc/manual/en/41-core_tools.md
+++ b/doc/manual/en/41-core_tools.md
@@ -199,6 +199,51 @@ restart orangu
 
 \newpage
 
+## /prune
+
+Deletes session directories from `~/.orangu/sessions/`. The active session is never deleted regardless of strategy.
+
+With a UUID it deletes that single session. With `all` it deletes every session except the active one. With `--workspace <path>` (or `-w <path>`) it deletes all sessions whose recorded workspace path contains `<path>`. With `--older-than <days>` (or `-o <days>`) it deletes all sessions whose `last_updated_at` timestamp is more than `<days>` days in the past.
+
+Tab completion after `/prune ` cycles through session UUIDs newest-first.
+
+### Examples
+
+Delete a single session by UUID:
+
+```text
+/prune 550e8400-e29b-41d4-a716-446655440000
+```
+
+Delete all sessions except the active one:
+
+```text
+/prune all
+```
+
+Delete all sessions for a workspace:
+
+```text
+/prune -w myproject
+```
+
+Delete sessions not used in the last 30 days:
+
+```text
+/prune -o 30
+```
+
+Natural-language forms:
+
+```text
+prune session 550e8400-e29b-41d4-a716-446655440000
+prune all
+prune sessions in myproject
+prune sessions older than 30
+```
+
+\newpage
+
 ## /session
 
 Lists, switches, and opens sessions. See the Sessions section of the Terminal interface chapter for how sessions are stored, auto-resumed, and cleaned up.

--- a/src/bin/orangu/commands.rs
+++ b/src/bin/orangu/commands.rs
@@ -155,6 +155,13 @@ pub enum CloseTarget {
     PullRequest(u64),
 }
 
+pub enum PruneTarget {
+    Uuid(String),
+    Workspace(String),
+    OlderThan(u64),
+    All,
+}
+
 pub enum StashSubcommand {
     Push,
     Pop,
@@ -191,6 +198,7 @@ pub enum LocalCommand<'a> {
     Pull(Option<u64>),
     Comment(Option<(u64, CommentBody<'a>)>),
     Close(Option<CloseTarget>),
+    Prune(Option<PruneTarget>),
     CreatePullRequest,
     Rebase,
     Merge(Option<Cow<'a, str>>),
@@ -275,6 +283,7 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
         "/pull" => Some(LocalCommand::Pull(None)),
         "/comment" => Some(LocalCommand::Comment(None)),
         "/close" => Some(LocalCommand::Close(None)),
+        "/prune" => Some(LocalCommand::Prune(None)),
         "/pull_request" => Some(LocalCommand::CreatePullRequest),
         "/review" => Some(LocalCommand::Review),
         "/push" => Some(LocalCommand::Push(false)),
@@ -331,6 +340,9 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
             }
             if let Some(args) = input.strip_prefix("/close ") {
                 return Some(LocalCommand::Close(parse_close_args(args.trim())));
+            }
+            if let Some(args) = input.strip_prefix("/prune ") {
+                return Some(LocalCommand::Prune(parse_prune_args(args.trim())));
             }
             if let Some(args) = input.strip_prefix("/merge ") {
                 let branch = args.trim();
@@ -716,6 +728,12 @@ pub const NATURAL_LANGUAGE_BINDINGS: &[&str] = &[
     "sessions",
     "list sessions",
     "show sessions",
+    // --- prune ---
+    "prune session ",
+    "prune sessions older than ",
+    "prune sessions in ",
+    "prune all",
+    "prune",
     // --- usage ---
     "usage",
     "show usage",
@@ -1098,6 +1116,25 @@ pub fn parse_natural_language_command(input: &str) -> Option<LocalCommand<'_>> {
     ) {
         return Some(LocalCommand::Session(None));
     }
+    for prefix in ["prune session ", "prune sessions older than "] {
+        if let Some(rest) = strip_ascii_prefix(input, prefix) {
+            return Some(LocalCommand::Prune(parse_prune_args(rest.trim())));
+        }
+    }
+    if let Some(rest) = strip_ascii_prefix(input, "prune sessions in ") {
+        let path = rest.trim();
+        if !path.is_empty() {
+            return Some(LocalCommand::Prune(Some(PruneTarget::Workspace(
+                path.to_string(),
+            ))));
+        }
+    }
+    if matches_ci(input, &["prune all"]) {
+        return Some(LocalCommand::Prune(Some(PruneTarget::All)));
+    }
+    if matches_ci(input, &["prune"]) {
+        return Some(LocalCommand::Prune(None));
+    }
     if matches_ci(input, &["usage", "show usage"]) {
         return Some(LocalCommand::Usage);
     }
@@ -1361,6 +1398,36 @@ pub fn restore_usage_message() -> &'static str {
 
 pub fn grep_usage_message() -> &'static str {
     "Usage: /grep <pattern>. Use /help to see available commands."
+}
+
+pub fn parse_prune_args(input: &str) -> Option<PruneTarget> {
+    if input.eq_ignore_ascii_case("all") {
+        return Some(PruneTarget::All);
+    }
+    if let Some(rest) = input
+        .strip_prefix("--workspace ")
+        .or_else(|| input.strip_prefix("-w "))
+    {
+        let path = rest.trim();
+        if !path.is_empty() {
+            return Some(PruneTarget::Workspace(path.to_string()));
+        }
+        return None;
+    }
+    if let Some(rest) = input
+        .strip_prefix("--older-than ")
+        .or_else(|| input.strip_prefix("-o "))
+    {
+        return rest.trim().parse::<u64>().ok().map(PruneTarget::OlderThan);
+    }
+    if !input.is_empty() {
+        return Some(PruneTarget::Uuid(input.to_string()));
+    }
+    None
+}
+
+pub fn prune_usage_message() -> &'static str {
+    "Usage: /prune <uuid> | /prune --workspace <path> | /prune --older-than <days>. Use /help to see available commands."
 }
 
 pub fn add_file_usage_message() -> &'static str {

--- a/src/bin/orangu/completion.rs
+++ b/src/bin/orangu/completion.rs
@@ -46,6 +46,7 @@ pub const COMMANDS: &[&str] = &[
     "/pull",
     "/comment",
     "/close",
+    "/prune",
     "/rebase",
     "/merge",
     "/branch",
@@ -444,6 +445,17 @@ fn structured_completion_candidates(
             candidates = session_path_completion_candidates(arg_prefix);
         }
         return Some(("/session ".len(), cursor, candidates));
+    }
+
+    if let Some(uuid_prefix) = prefix.strip_prefix("/prune ")
+        && !uuid_prefix.starts_with('-')
+        && !uuid_prefix.eq_ignore_ascii_case("all")
+    {
+        let candidates = session_uuids_newest_first()
+            .into_iter()
+            .filter(|u| u.starts_with(uuid_prefix))
+            .collect();
+        return Some(("/prune ".len(), cursor, candidates));
     }
 
     None

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -59,11 +59,12 @@ use anyhow::Error;
 use commands::ReviewLaunch;
 use commands::{
     BranchSubcommand, CommandContext, CommandOutcome, CommandState, LocalCommand, LocalError,
-    StashSubcommand, add_file_usage_message, amend_usage_message, cherry_pick_usage_message,
-    close_usage_message, comment_usage_message, commit_usage_message, grep_usage_message,
-    merge_usage_message, model_usage_message, move_file_usage_message, open_file_usage_message,
-    parse_local_command, pull_usage_message, remove_file_usage_message, restore_usage_message,
-    server_usage_message, sorted_model_names, system_prompt,
+    PruneTarget, StashSubcommand, add_file_usage_message, amend_usage_message,
+    cherry_pick_usage_message, close_usage_message, comment_usage_message, commit_usage_message,
+    grep_usage_message, merge_usage_message, model_usage_message, move_file_usage_message,
+    open_file_usage_message, parse_local_command, prune_usage_message, pull_usage_message,
+    remove_file_usage_message, restore_usage_message, server_usage_message, sorted_model_names,
+    system_prompt,
 };
 use git::{
     Forge, add_file_output, amend_output, branch_create_output, branch_delete_output,
@@ -1480,6 +1481,15 @@ fn handle_command(
                 _ => {}
             }
             match list_sessions_output(Some(arg.as_ref()), &usage_stats.session_id) {
+                Ok(output) => Ok(CommandOutcome::Output(output)),
+                Err(err) => Ok(local_command_error(err)),
+            }
+        }
+        LocalCommand::Prune(None) => Ok(CommandOutcome::OutputError(
+            prune_usage_message().to_string(),
+        )),
+        LocalCommand::Prune(Some(target)) => {
+            match prune_sessions_output(&target, &usage_stats.session_id) {
                 Ok(output) => Ok(CommandOutcome::Output(output)),
                 Err(err) => Ok(local_command_error(err)),
             }
@@ -3133,6 +3143,81 @@ fn list_sessions_output(workspace_filter: Option<&str>, active_session: &str) ->
             "{dot}       {:<w_uuid$}  {:<w_started$}  {:<w_last$}  {:>w_cmds$}  {:<w_branch$}  {}",
             row.uuid, row.started, row.last, row.cmds, row.branch, row.workspace
         ));
+    }
+    Ok(lines.join("\n"))
+}
+
+fn prune_sessions_output(target: &PruneTarget, active_session: &str) -> Result<String> {
+    let sessions_dir = {
+        let home = home::home_dir().ok_or_else(|| anyhow!("failed to resolve home directory"))?;
+        home.join(SESSIONS_DIRECTORY)
+    };
+
+    if !sessions_dir.exists() {
+        return Ok("No sessions found.".to_string());
+    }
+
+    let now = current_unix_timestamp();
+
+    let mut removed: Vec<String> = Vec::new();
+    let mut skipped_active = false;
+
+    for entry in std::fs::read_dir(&sessions_dir).with_context(|| {
+        format!(
+            "failed to read sessions directory {}",
+            sessions_dir.display()
+        )
+    })? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let uuid = match path.file_name().and_then(|n| n.to_str()) {
+            Some(name) => name.to_string(),
+            None => continue,
+        };
+
+        let should_remove = match target {
+            PruneTarget::All => true,
+            PruneTarget::Uuid(id) => uuid == *id,
+            PruneTarget::Workspace(filter) => {
+                let meta = load_session_metadata(&path.join("metadata")).ok().flatten();
+                meta.map(|m| m.workspace.contains(filter.as_str()))
+                    .unwrap_or(false)
+            }
+            PruneTarget::OlderThan(days) => {
+                let threshold = days * 86400;
+                let meta = load_session_metadata(&path.join("metadata")).ok().flatten();
+                meta.map(|m| now.saturating_sub(m.last_updated_at) >= threshold)
+                    .unwrap_or(false)
+            }
+        };
+
+        if !should_remove {
+            continue;
+        }
+
+        if uuid == active_session {
+            skipped_active = true;
+            continue;
+        }
+
+        std::fs::remove_dir_all(&path)
+            .with_context(|| format!("failed to remove session directory {}", path.display()))?;
+        removed.push(uuid);
+    }
+
+    if removed.is_empty() && !skipped_active {
+        return Ok("No matching sessions found.".to_string());
+    }
+
+    let mut lines: Vec<String> = Vec::new();
+    for uuid in &removed {
+        lines.push(format!("Removed: {uuid}"));
+    }
+    if skipped_active {
+        lines.push(format!("Skipped active session: {active_session}"));
     }
     Ok(lines.join("\n"))
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -178,6 +178,7 @@ pub fn help_text() -> &'static str {
 /restart                                      Restart orangu, resuming the same workspace and session
 /tools                                        List tools
 /model [name]                                 List the server's models (active green), or switch to a specific one
+/prune [<uuid>|-w <path>|-o <days>|all]       Remove sessions
 /session [uuid|workspace]                     List/switch sessions, or open a workspace directory (Tab completes UUIDs, workspaces, then filesystem paths)
 /list_files                                   List workspace files as a tree
 /open_file <path>                             Open a workspace file in $EDITOR
@@ -210,7 +211,7 @@ pub fn help_text() -> &'static str {
 /clear                                        Clear the current conversation
 /quit                                         Exit the client
 
-Natural-language forms such as `open README.md`, `list models`, `list files`, `pull 58`, `log`, `status`, `rebase`, `squash`, `merge feature/foo`, `grep <pattern>`, `find <pattern>`, `branch`, `list branches`, `checkout main`, `switch to main`, `create branch feature/x`, `rename to new-name`, `delete feature/foo`, `restore README.md`, `add README.md`, `remove README.md`, `move old.rs new.rs`, `cherry pick abc1234`, `commit "[#42] My feature"`, `amend "[#42] My feature"`, `push`, `force push`, `add comment on 51 "My comment"`, `review`, `create pull request`, `stash`, `stash pop`, `stash list`, `stash drop`, `init repo`, `restart`, and `show help` are also handled locally.
+Natural-language forms such as `open README.md`, `list models`, `list files`, `pull 58`, `log`, `status`, `rebase`, `squash`, `merge feature/foo`, `grep <pattern>`, `find <pattern>`, `branch`, `list branches`, `checkout main`, `switch to main`, `create branch feature/x`, `rename to new-name`, `delete feature/foo`, `restore README.md`, `add README.md`, `remove README.md`, `move old.rs new.rs`, `cherry pick abc1234`, `commit "[#42] My feature"`, `amend "[#42] My feature"`, `push`, `force push`, `add comment on 51 "My comment"`, `review`, `create pull request`, `stash`, `stash pop`, `stash list`, `stash drop`, `init repo`, `prune session <uuid>`, `prune all`, `prune sessions older than <days>`, `prune sessions in <path>`, `restart`, and `show help` are also handled locally.
 
 The prompt uses standard Unix shell keys, including Ctrl+Left, Ctrl+Right, Ctrl+A, Ctrl+E, Ctrl+K, Ctrl+U, Ctrl+W, Alt+Backspace, Alt+D, and Tab completion.
 


### PR DESCRIPTION
Closes #85

## Changes

- `LocalCommand::Prune(Option<PruneTarget>)` with variants `Uuid`, `Workspace`, `OlderThan`, and `All`
- `/prune <uuid>` : remove a session by UUID; Tab completion cycles session UUIDs newest-first
- `/prune all` : remove all sessions except the active one
- `/prune --workspace <path>` / `-w` : remove all sessions whose workspace path contains the given string
- `/prune --older-than <days>` / `-o` : remove sessions not updated within the given number of days
- The active session is never removed regardless of strategy
- Natural-language aliases: `prune session <uuid>`, `prune all`, `prune sessions older than <days>`, `prune sessions in <path>`
- Updated `/help`, Tab completion, and `doc/manual/en/40-terminal.md`
