### PR TITLE
[#105] install.sh / install.cmd: one-liner installer for Linux, macOS and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,73 @@
 
 ## Installation
 
-### Install dependencies on Fedora
+### One-liner install (Linux, macOS, Windows)
 
-Install the tools needed to build and run **orangu** from source:
+**Linux / macOS** (requires `curl` or `wget`, and `tar`):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/mnemosyne-systems/orangu/main/install.sh | sh
+```
+
+**Windows** (requires PowerShell, included with Windows 10 and later):
+
+```cmd
+curl -fsSL https://raw.githubusercontent.com/mnemosyne-systems/orangu/main/install.cmd -o install.cmd && install.cmd
+```
+
+Both scripts download the latest release binary, install it to `~/.local/bin` (Linux/macOS) or `%USERPROFILE%\.local\bin` (Windows), and warn if the directory is not in your `PATH`.
+
+**Custom install directory:** set `INSTALL_DIR` before running the script:
+
+```sh
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/mnemosyne-systems/orangu/main/install.sh | INSTALL_DIR=/usr/local/bin sh
+```
+
+```cmd
+:: Windows
+set "INSTALL_DIR=C:\Tools" && install.cmd
+```
+
+**Shell completions:** after installing, run `orangu -s` to print the completion script for your shell:
+
+```sh
+# bash
+orangu -s >> ~/.bashrc && source ~/.bashrc
+
+# zsh
+orangu -s >> ~/.zshrc && source ~/.zshrc
+
+# fish
+orangu -s | source
+```
+
+On Windows, add `Invoke-Expression (orangu -s)` to your PowerShell `$PROFILE`.
+
+### Build from source
+
+#### Install dependencies
+
+**Fedora / RHEL:**
 
 ```sh
 dnf install -y git rust cargo
 ```
 
-### Release build
+**Debian / Ubuntu:**
+
+```sh
+apt-get install -y git curl
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+**macOS:**
+
+```sh
+brew install rust
+```
+
+#### Release build
 
 The following commands build an optimized release binary:
 
@@ -71,7 +129,7 @@ To install it system-wide:
 sudo install -Dm755 target/release/orangu /usr/local/bin/orangu
 ```
 
-### Debug build
+#### Debug build
 
 The following commands build a debug binary:
 

--- a/doc/manual/en/03-quickstart.md
+++ b/doc/manual/en/03-quickstart.md
@@ -4,6 +4,30 @@
 
 This chapter gets **orangu** running against a local OpenAI-compatible server such as **llama.cpp** with the sample configuration in `doc/etc/orangu.conf`.
 
+## Install orangu
+
+The quickest way to install the latest release binary is the one-liner installer.
+
+**Linux / macOS:**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/mnemosyne-systems/orangu/main/install.sh | sh
+```
+
+**Windows** (Command Prompt):
+
+```cmd
+curl -fsSL https://raw.githubusercontent.com/mnemosyne-systems/orangu/main/install.cmd -o install.cmd && install.cmd
+```
+
+**Windows** (PowerShell alternative):
+
+```powershell
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/mnemosyne-systems/orangu/main/install.cmd -OutFile install.cmd; .\install.cmd
+```
+
+The script installs to `~/.local/bin` (Linux/macOS) or `%USERPROFILE%\.local\bin` (Windows) and warns if the directory is not in your `PATH`. See [BUILDING.md](../../BUILDING.md) for instructions on building from source.
+
 ## Start llama.cpp
 
 Run `llama-server` with your preferred model, for example:

--- a/install.cmd
+++ b/install.cmd
@@ -1,0 +1,54 @@
+@echo off
+:: Copyright (C) 2026 The orangu community
+::
+:: This program is free software: you can redistribute it and/or modify
+:: it under the terms of the GNU General Public License as published by
+:: the Free Software Foundation, either version 3 of the License, or
+:: (at your option) any later version.
+::
+:: This program is distributed in the hope that it will be useful,
+:: but WITHOUT ANY WARRANTY; without even the implied warranty of
+:: MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+:: GNU General Public License for more details.
+::
+:: You should have received a copy of the GNU General Public License
+:: along with this program. If not, see <https://www.gnu.org/licenses/>.
+:: Usage: curl -fsSL https://raw.githubusercontent.com/mnemosyne-systems/orangu/main/install.cmd -o install.cmd && install.cmd
+:: Override install directory: set "INSTALL_DIR=C:\Tools" && install.cmd
+setlocal EnableDelayedExpansion
+
+set "REPO=mnemosyne-systems/orangu"
+if not defined INSTALL_DIR set "INSTALL_DIR=%USERPROFILE%\.local\bin"
+set "TMP=%TEMP%\orangu-install-%RANDOM%%RANDOM%"
+
+where powershell >nul 2>&1 || (echo error: PowerShell is required & exit /b 1)
+
+echo Fetching latest release...
+for /f "usebackq delims=" %%v in (`powershell -NoProfile -NonInteractive -Command ^
+    "(Invoke-RestMethod 'https://api.github.com/repos/%REPO%/releases/latest').tag_name"`) do set "VERSION=%%v"
+if "!VERSION!"=="" (echo error: could not fetch latest release & exit /b 1)
+echo Version: !VERSION!
+
+set "ASSET=orangu-!VERSION!-x86_64-pc-windows-msvc.zip"
+set "URL=https://github.com/%REPO%/releases/download/!VERSION!/!ASSET!"
+
+echo Downloading !ASSET!...
+mkdir "!TMP!" >nul 2>&1
+powershell -NoProfile -NonInteractive -Command ^
+    "Invoke-WebRequest -Uri '!URL!' -OutFile '!TMP!\!ASSET!' -UseBasicParsing" || ^
+    (echo error: download failed & rd /s /q "!TMP!" >nul 2>&1 & exit /b 1)
+
+powershell -NoProfile -NonInteractive -Command ^
+    "$ErrorActionPreference='Stop'; Expand-Archive -Path '!TMP!\!ASSET!' -DestinationPath '!TMP!\out' -Force" || ^
+    (echo error: could not extract archive & rd /s /q "!TMP!" >nul 2>&1 & exit /b 1)
+if not exist "!TMP!\out\orangu.exe" (echo error: binary not found in archive & rd /s /q "!TMP!" >nul 2>&1 & exit /b 1)
+
+if not exist "!INSTALL_DIR!" mkdir "!INSTALL_DIR!"
+copy /y "!TMP!\out\orangu.exe" "!INSTALL_DIR!\orangu.exe" >nul || ^
+    (echo error: could not write to !INSTALL_DIR! & exit /b 1)
+
+rd /s /q "!TMP!" >nul 2>&1
+echo Installed: !INSTALL_DIR!\orangu.exe
+echo Run "orangu --help" to get started.
+echo Run "orangu -s" and add the output to your PowerShell $PROFILE for completions.
+endlocal

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# Copyright (C) 2026 The orangu community
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# Usage: curl -fsSL https://raw.githubusercontent.com/mnemosyne-systems/orangu/main/install.sh | sh
+# Override install directory: INSTALL_DIR=/usr/local/bin sh install.sh
+set -e
+
+REPO="mnemosyne-systems/orangu"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+
+if command -v curl >/dev/null 2>&1; then
+    fetch()    { curl -fsSL "$1"; }
+    fetch_to() { curl -fsSL -o "$2" "$1"; }
+elif command -v wget >/dev/null 2>&1; then
+    fetch()    { wget -qO- "$1"; }
+    fetch_to() { wget -qO "$2" "$1"; }
+else
+    echo "error: curl or wget is required" >&2; exit 1
+fi
+
+command -v tar >/dev/null 2>&1 || { echo "error: tar is required" >&2; exit 1; }
+
+# Detect OS and architecture
+case "$(uname -s)" in
+    Linux)  OS="linux" ;;
+    Darwin) OS="darwin" ;;
+    *)      echo "error: unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+    x86_64)        ARCH="x86_64" ;;
+    aarch64|arm64) ARCH="aarch64" ;;
+    *)             echo "error: unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+# On Linux, detect glibc vs musl
+if [ "$OS" = "linux" ]; then
+    if ldd --version 2>&1 | grep -qi musl; then LIBC="musl"; else LIBC="gnu"; fi
+    TARGET="${ARCH}-unknown-linux-${LIBC}"
+else
+    TARGET="${ARCH}-apple-darwin"
+fi
+
+echo "Platform: ${TARGET}"
+
+# Resolve latest release
+VERSION=$(fetch "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+[ -n "$VERSION" ] || { echo "error: could not fetch latest release" >&2; exit 1; }
+echo "Version:  ${VERSION}"
+
+ASSET="orangu-${VERSION}-${TARGET}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Downloading ${ASSET}..."
+fetch_to "$URL" "${TMP}/${ASSET}" || { echo "error: download failed: ${URL}" >&2; exit 1; }
+
+tar -xzf "${TMP}/${ASSET}" -C "$TMP" || { echo "error: could not extract ${ASSET}" >&2; exit 1; }
+[ -f "${TMP}/orangu" ] || { echo "error: binary not found in archive" >&2; exit 1; }
+
+mkdir -p "$INSTALL_DIR"
+[ -w "$INSTALL_DIR" ] || { echo "error: ${INSTALL_DIR} is not writable — try sudo or set INSTALL_DIR" >&2; exit 1; }
+
+cp "${TMP}/orangu" "${INSTALL_DIR}/orangu"
+chmod +x "${INSTALL_DIR}/orangu"
+echo "Installed: ${INSTALL_DIR}/orangu"
+
+case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *) echo "warning: ${INSTALL_DIR} is not in your PATH — add: export PATH=\"${INSTALL_DIR}:\$PATH\"" ;;
+esac
+
+echo ""
+echo "Run 'orangu --help' to get started."
+echo "Run 'orangu -s' to set up shell completions."

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Copyright (C) 2026 The orangu community
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# Run with: sh tests/install_test.sh
+set -e
+pass=0; fail=0
+check() { if [ "$1" = "$2" ]; then pass=$((pass+1)); else fail=$((fail+1)); printf "FAIL: %s (got '%s')\n" "$3" "$2"; fi; }
+
+# OS detection
+check "linux"       "$(case Linux  in Linux) echo linux;; Darwin) echo darwin;; *) echo unsupported;; esac)" "Linux"
+check "darwin"      "$(case Darwin in Linux) echo linux;; Darwin) echo darwin;; *) echo unsupported;; esac)" "Darwin"
+check "unsupported" "$(case Other  in Linux) echo linux;; Darwin) echo darwin;; *) echo unsupported;; esac)" "unknown OS"
+
+# Arch detection
+check "x86_64"      "$(case x86_64  in x86_64) echo x86_64;; aarch64|arm64) echo aarch64;; *) echo unsupported;; esac)" "x86_64"
+check "aarch64"     "$(case aarch64 in x86_64) echo x86_64;; aarch64|arm64) echo aarch64;; *) echo unsupported;; esac)" "aarch64"
+check "aarch64"     "$(case arm64   in x86_64) echo x86_64;; aarch64|arm64) echo aarch64;; *) echo unsupported;; esac)" "arm64 alias"
+check "unsupported" "$(case armv7l  in x86_64) echo x86_64;; aarch64|arm64) echo aarch64;; *) echo unsupported;; esac)" "armv7l"
+
+# Target triple construction (mirrors the formula in install.sh)
+triple() {  # $1=os $2=arch $3=libc
+    if [ "$1" = "linux" ]; then echo "${2}-unknown-linux-${3}"; else echo "${2}-apple-darwin"; fi
+}
+check "x86_64-unknown-linux-gnu"   "$(triple linux  x86_64  gnu)"  "linux gnu triple"
+check "aarch64-unknown-linux-musl" "$(triple linux  aarch64 musl)" "linux musl triple"
+check "aarch64-apple-darwin"       "$(triple darwin aarch64 '')"   "darwin triple"
+
+# INSTALL_DIR default and override
+unset INSTALL_DIR
+check "$HOME/.local/bin" "${INSTALL_DIR:-$HOME/.local/bin}" "default INSTALL_DIR"
+INSTALL_DIR=/tmp/custom
+check "/tmp/custom" "${INSTALL_DIR:-$HOME/.local/bin}" "custom INSTALL_DIR"
+unset INSTALL_DIR
+
+# Writable directory and cleanup
+TMP=$(mktemp -d); rm -rf "$TMP"
+check "" "$([ ! -d "$TMP" ] && echo '')" "temp dir cleaned up"
+
+printf "%d passed, %d failed\n" "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Adds `install.sh` and `install.cmd` so users can install orangu with a single command instead of building from source.

**Linux / macOS:**
```sh
curl -fsSL https://raw.githubusercontent.com/mnemosyne-systems/orangu/main/install.sh | sh
```

**Windows:**
```cmd
curl -fsSL https://raw.githubusercontent.com/mnemosyne-systems/orangu/main/install.cmd -o install.cmd && install.cmd
```

Both scripts auto-detect the platform, fetch the latest release from the GitHub API, and install the binary to `~/.local/bin` / `%USERPROFILE%\.local\bin`. On Linux, libc variant (gnu vs musl) is detected automatically. A PATH warning is shown if the install directory is not on the user's path. `INSTALL_DIR` can be set to override the destination.

README and quickstart manual updated with install instructions.

Closes #105
