### PR TITLE
[#30] Workspace tabs: live switching, Alt keys, status line

### DIFF
--- a/doc/manual/en/03-quickstart.md
+++ b/doc/manual/en/03-quickstart.md
@@ -173,7 +173,7 @@ comment on 42 with auto review  # post it on GitHub/GitLab issue/PR #42
 
 By default the tools operate on the current directory. Use `--workspace /path/to/project` to point **orangu** at another tree.
 
-The startup flags have short forms: `-c` for `--config`, `-w` for `--workspace`, `-r` for `--resume`, and `-i` for `--init`.
+The startup flags have short forms: `-c` for `--config`, `-w` for `--workspace`, `-r` for `--resume`, `-i` for `--init`, and `-a` for `--all` (reopen the tabs from the previous run).
 
 **orangu** automatically resumes an existing session when you return to the same workspace and Git branch. When a previous session is found, the status bar shows:
 

--- a/doc/manual/en/31-workspaces.md
+++ b/doc/manual/en/31-workspaces.md
@@ -4,9 +4,11 @@
 
 A *workspace* is the project directory orangu is open on. It is the directory the model's tools read from and write to, the directory whose Git branch drives the prompt and the Git and review commands, and the directory a session belongs to. By default the workspace is the directory you launched orangu in; pass `--workspace <path>` (or `-w <path>`) at startup to begin somewhere else.
 
-The `/workspace` command reports the active workspace and switches between workspaces without leaving the client. Each workspace is its own session, so switching to a workspace resumes the session you last had open there, or starts a fresh one when there is none. See the Sessions section of the Terminal interface chapter for how sessions are matched to a workspace and branch.
+Several workspaces can be open at once as tabs in a single orangu, instead of running one instance per project. Each tab is its own session — its own conversation, scrollback, pending queue and command history — so switching tabs returns to exactly where you left that workspace, or resumes the session it last had. A tab bar shows the open tabs with the active one in bold, placed where the `workspaces` setting puts it (see Tab placement); it appears once more than one workspace is open. When `feedback` is on, a colored dot precedes each tab number: green for a valid tab, red when the tab's branch has been deleted or changed underneath it, and a blinking white dot on the active tab while it is processing a response. See the Sessions section of the Terminal interface chapter for how sessions are matched to a workspace and branch.
 
-Where the workspace tabs are drawn is set by the `workspaces` key in the `[orangu]` configuration section; see the Tab placement section below.
+Pass `-a` or `--all` at startup to reopen the tabs that were open at the end of the previous run. Their workspace directories and auto-resumed sessions are restored behind the initial tab.
+
+You move between tabs with the `/workspace` command or the workspace key bindings, and choose where the tab bar sits with the `workspaces` configuration key — both are described below.
 
 \newpage
 
@@ -14,7 +16,7 @@ Where the workspace tabs are drawn is set by the `workspaces` key in the `[orang
 
 With no argument, `/workspace` reports the active workspace directory.
 
-A bare number selects a workspace by its tab number; anything else is treated as a directory path. Switching to a directory opens it as a workspace and resumes the matching session there, or starts a fresh one if there is none.
+A bare number switches to the open tab with that number. Anything else is treated as a directory path: orangu switches to the tab already open on it, or opens a new tab for it (resuming the matching session there, or starting a fresh one). `Alt+Insert` opens a fresh tab on the current directory immediately; you then re-point it with `/workspace <path>`.
 
 Tab completion offers the workspaces seen in earlier sessions first, then completes filesystem directories, so a directory that has never been opened can still be navigated to a segment at a time:
 
@@ -43,13 +45,35 @@ switch workspace ~/projects/orangu
 
 \newpage
 
+## Key bindings
+
+At the prompt, the workspace tabs are driven by these keys:
+
+| Key | Action |
+| :-- | :-- |
+| `Alt+,` | Switch to the previous tab (to the left), wrapping |
+| `Alt+.` | Switch to the next tab (to the right), wrapping |
+| `Alt+Insert` | Open a new workspace tab (re-point it with `/workspace`) |
+| `Alt+Delete` | Close the active tab |
+
+Closing a tab renumbers the ones after it and moves focus to a neighbour. The last open tab is never closed — only `/quit` ends orangu. The keys work at the prompt and during streaming: pressing one while the model is responding parks the stream in the background and switches immediately. The response keeps running in the original tab; a blinking dot in the tab bar shows it is still active. Switching back re-attaches the live view so you can watch it complete. Press Escape twice to cancel a response whether it is running in the foreground or in the background.
+
+\newpage
+
 ## Tab placement
 
-Where the workspace tabs are shown is set by the `workspaces` key in the `[orangu]` section of the configuration file:
+Where the workspace tab bar is shown is set by the `workspaces` key in the `[orangu]` section of the configuration file:
 
 ```ini
 [orangu]
 workspaces = top
 ```
 
-The options are `top` (the default), `bottom`, `left`, and `right`, matched case-insensitively. The interactive `--init` wizard prompts for it with Tab completion. Leaving the key out uses `top`; an unrecognised value is rejected when the configuration is loaded. The full list of `[orangu]` keys is in the Configuration chapter.
+The options, matched case-insensitively, are:
+
+- `top` (the default) — a horizontal bar across the top of the screen, above the banner.
+- `bottom` — a horizontal bar across the bottom, under the input.
+- `left` — a vertical column of tab numbers down the left edge, beside the banner and output.
+- `right` — the same column down the right edge.
+
+The interactive `--init` wizard prompts for it with Tab completion. Leaving the key out uses `top`; an unrecognised value is rejected when the configuration is loaded. The full list of `[orangu]` keys is in the Configuration chapter.

--- a/doc/manual/en/40-terminal.md
+++ b/doc/manual/en/40-terminal.md
@@ -19,6 +19,7 @@ The sync runs in the background so it never delays startup. Its progress and res
 | `-c`  | `--config`    | Path to the configuration file (`orangu.conf`).               |
 | `-w`  | `--workspace` | Workspace root the local tools operate on. Defaults to `.`.   |
 | `-r`  | `--resume`    | Resume a specific session by UUID.                            |
+| `-a`  | `--all`       | Reopen the workspace tabs that were open at the end of the last run. |
 
 ## Header
 

--- a/src/bin/orangu/commands/mod.rs
+++ b/src/bin/orangu/commands/mod.rs
@@ -134,6 +134,12 @@ pub enum CommandOutcome {
     /// Re-exec into a different workspace directory, starting (or auto-resuming)
     /// a session there.
     SwitchWorkspace(PathBuf),
+    /// Switch to the open workspace tab at the given full-order index
+    /// (`/workspace <number>`).
+    SwitchWorkspaceTab(usize),
+    /// Open a directory as a workspace tab, or switch to it if already open
+    /// (`/workspace <path>`).
+    OpenWorkspaceTab(PathBuf),
     Blocking(Box<dyn FnOnce() -> anyhow::Result<String> + Send + 'static>),
     /// A long-running command that streams its output line by line through the
     /// sink as it is produced, rather than returning it all at once.

--- a/src/bin/orangu/dispatch.rs
+++ b/src/bin/orangu/dispatch.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::commands::system_prompt_with_skills;
 use crate::*;
 
 pub(crate) fn local_command_error(err: Error) -> CommandOutcome {
@@ -652,31 +653,19 @@ pub(crate) fn handle_command(
         LocalCommand::Workspace(Some(arg)) => {
             let arg = arg.trim();
             // A bare integer is a tab number ("number is the tab, everything
-            // else is a directory"). Until tabs share one process, the active
-            // workspace is the only one open, so it is tab 1; any other number
-            // has no tab to switch to yet.
+            // else is a directory"); switch to that tab.
             if let Ok(number) = arg.parse::<usize>() {
                 if number == 0 {
                     return Ok(CommandOutcome::OutputError(
                         "Workspace numbers start at 1.".to_string(),
                     ));
                 }
-                if number == 1 {
-                    return Ok(CommandOutcome::Output("Already in workspace 1".to_string()));
-                }
-                return Ok(CommandOutcome::OutputError(format!(
-                    "No workspace {number} is open."
-                )));
+                return Ok(CommandOutcome::SwitchWorkspaceTab(number - 1));
             }
-            // Otherwise the argument is a directory: open it, or report it is
-            // already the active workspace. Re-exec into a real directory the
-            // same way `/session <path>` opens a new workspace.
+            // Otherwise the argument is a directory: open it as a tab, or switch
+            // to it if it is already open.
             match resolve_existing_dir_arg(arg) {
-                Some(dir) if dir == workspace => Ok(CommandOutcome::Output(format!(
-                    "Already in workspace {}",
-                    dir.display()
-                ))),
-                Some(dir) => Ok(CommandOutcome::SwitchWorkspace(dir)),
+                Some(dir) => Ok(CommandOutcome::OpenWorkspaceTab(dir)),
                 None => Ok(CommandOutcome::OutputError(format!(
                     "No such directory: {arg}"
                 ))),
@@ -1036,29 +1025,27 @@ mod tests {
             _ => panic!("expected the active workspace to be reported"),
         }
 
-        // Tab 1 is the active workspace; 0 and any higher number have no tab.
-        assert!(matches!(run("/workspace 1"), CommandOutcome::Output(_)));
+        // A number switches to that tab (0-based index); the loop resolves
+        // whether the tab exists. Zero is rejected up front.
+        assert!(matches!(
+            run("/workspace 1"),
+            CommandOutcome::SwitchWorkspaceTab(0)
+        ));
+        assert!(matches!(
+            run("/workspace 5"),
+            CommandOutcome::SwitchWorkspaceTab(4)
+        ));
         assert!(matches!(
             run("/workspace 0"),
             CommandOutcome::OutputError(_)
         ));
-        assert!(matches!(
-            run("/workspace 2"),
-            CommandOutcome::OutputError(_)
-        ));
 
-        // The active workspace's own path is a no-op switch.
-        match run(&format!("/workspace {}", here.display())) {
-            CommandOutcome::Output(message) => assert!(message.contains("Already in workspace")),
-            _ => panic!("expected a no-op for the active workspace path"),
-        }
-
-        // A different existing directory re-execs into it.
+        // An existing directory opens (or switches to) a tab for it.
         match run(&format!("/workspace {}", other.path().display())) {
-            CommandOutcome::SwitchWorkspace(dir) => {
+            CommandOutcome::OpenWorkspaceTab(dir) => {
                 assert_eq!(dir, crate::normalize_path(other.path()));
             }
-            _ => panic!("expected a workspace switch for a different directory"),
+            _ => panic!("expected a workspace tab open for a directory"),
         }
 
         // A path that is not a directory is rejected.

--- a/src/bin/orangu/input.rs
+++ b/src/bin/orangu/input.rs
@@ -15,13 +15,18 @@
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use orangu::{
-    llm::StreamMetrics,
-    tui::{Banner, HeaderStatus, StatusFragment, TranscriptLine, visible_line_width},
+    llm::{ChatMessage, StreamMetrics},
+    session::ChatSession,
+    tui::{
+        Banner, HeaderStatus, StatusFragment, TabStatus, TranscriptLine, WorkspaceTabsView,
+        visible_line_width,
+    },
 };
 use std::{
     collections::VecDeque,
     io::Write,
     path::Path,
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
@@ -50,6 +55,27 @@ pub enum InputResult {
     Submitted(String),
     Refresh,
     Quit,
+    /// Move focus to the previous workspace tab (`Alt+,`).
+    WorkspacePrevious,
+    /// Move focus to the next workspace tab (`Alt+.`).
+    WorkspaceNext,
+    /// Start a new workspace tab (`Alt+Insert`).
+    WorkspaceNew,
+    /// Close the active workspace tab (`Alt+Delete`).
+    WorkspaceClose,
+}
+
+/// An LLM response that is streaming in a background tokio task while the user
+/// has switched to another workspace tab. The handle owns the `ChatSession`
+/// and returns it together with the result when it finishes.
+pub struct PendingResponse {
+    pub(crate) stream_state: Arc<Mutex<StreamRenderState>>,
+    pub(crate) handle: tokio::task::JoinHandle<(ChatSession, anyhow::Result<String>)>,
+    pub(crate) llm_start: std::time::Instant,
+    pub(crate) tool_time_before: std::time::Duration,
+    /// Snapshot of session messages taken before the spawn so we can restore a
+    /// clean session if the user later presses Escape to cancel the response.
+    pub(crate) saved_messages: Vec<ChatMessage>,
 }
 
 pub enum WaitResult {
@@ -60,6 +86,9 @@ pub enum WaitResult {
         error: anyhow::Error,
     },
     Quit,
+    /// The prompt future is running in a background task; the caller should
+    /// store the [`PendingResponse`] on the current tab and switch to another.
+    BackgroundStreaming(PendingResponse),
 }
 
 pub struct InputEventResult {
@@ -90,6 +119,12 @@ pub struct RenderContext<'a> {
     /// inline ghost.
     pub available_models: &'a [String],
     pub skills: &'a orangu::skills::SkillRegistry,
+    /// The workspace tab bar to draw, or `None` when a single workspace is
+    /// open. Placed per the `workspaces` configuration.
+    pub tab_bar: Option<WorkspaceTabsView>,
+    /// Per-tab status dots for the tab bar, in left-to-right order. Empty when
+    /// `feedback` is off or only one tab is open.
+    pub tab_statuses: &'a [TabStatus],
 }
 
 #[derive(Clone, Debug)]
@@ -229,6 +264,10 @@ pub struct WaitContext<'a> {
     pub thinking_quote: Option<&'static str>,
     pub viewport: &'a mut ViewportState,
     pub skills: &'a orangu::skills::SkillRegistry,
+    /// When a workspace-switch key (Alt+,/./Insert/Delete) is pressed during a
+    /// wait (streaming, blocking command), the action is stored here instead of
+    /// dropped, so `main` can apply it as soon as the wait returns.
+    pub deferred_tab: &'a mut Option<crate::workspace_tab::TabAction>,
 }
 
 #[derive(Default)]
@@ -638,6 +677,39 @@ pub fn handle_input_event(
                     interrupt_state.reset();
                     input_state.delete_forward_readline_word();
                     redraw = true;
+                }
+                (KeyCode::Char(','), modifiers)
+                    if modifiers.contains(KeyModifiers::ALT)
+                        && !modifiers.contains(KeyModifiers::CONTROL) =>
+                {
+                    return InputEventResult {
+                        redraw: false,
+                        outcome: Some(InputResult::WorkspacePrevious),
+                    };
+                }
+                (KeyCode::Char('.'), modifiers)
+                    if modifiers.contains(KeyModifiers::ALT)
+                        && !modifiers.contains(KeyModifiers::CONTROL) =>
+                {
+                    return InputEventResult {
+                        redraw: false,
+                        outcome: Some(InputResult::WorkspaceNext),
+                    };
+                }
+                (KeyCode::Insert, modifiers) if modifiers.contains(KeyModifiers::ALT) => {
+                    return InputEventResult {
+                        redraw: false,
+                        outcome: Some(InputResult::WorkspaceNew),
+                    };
+                }
+                (KeyCode::Delete, modifiers)
+                    if modifiers.contains(KeyModifiers::ALT)
+                        && !modifiers.contains(KeyModifiers::CONTROL) =>
+                {
+                    return InputEventResult {
+                        redraw: false,
+                        outcome: Some(InputResult::WorkspaceClose),
+                    };
                 }
                 (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
                     match interrupt_state.handle_interrupt(Instant::now()) {

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -31,6 +31,7 @@ mod shell;
 mod stats;
 mod terminal;
 mod wait;
+mod workspace_tab;
 
 #[cfg(test)]
 mod test_support;
@@ -53,9 +54,10 @@ use orangu::{
     tui::{
         AutoReviewRejectView, AutoReviewScreenArgs, FEEDBACK_ERR, FEEDBACK_OK, ReviewCommentEditor,
         ReviewEntry, ReviewFeedbackView, ReviewScreenArgs, ReviewStatus, ScreenRenderArgs,
-        StatusFragment, auto_review_pane_body_height, render_auto_review_screen,
-        render_review_screen, render_screen, render_thinking_status, render_tool_running_status,
-        render_working_status, review_pane_body_height, terminal_height, terminal_width,
+        StatusFragment, TabStatus, WorkspaceTabsView, auto_review_pane_body_height,
+        render_auto_review_screen, render_review_screen, render_screen, render_thinking_status,
+        render_tool_running_status, render_working_status, review_pane_body_height,
+        terminal_height, terminal_width,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -79,7 +81,6 @@ use commands::{
     merge_usage_message, model_usage_message, move_file_usage_message, open_file_usage_message,
     parse_local_command, prune_usage_message, pull_usage_message, remove_file_usage_message,
     restore_usage_message, server_usage_message, sorted_model_names, system_prompt,
-    system_prompt_with_skills,
 };
 use dispatch::*;
 use git::{
@@ -97,8 +98,8 @@ use git::{
 };
 use input::{
     EscapeCancelState, IDLE_STATUS_REFRESH_INTERVAL, InputContext, InputResult, InputState,
-    InterruptState, OutputState, RenderContext, ScreenState, StreamRenderState, ViewportState,
-    WaitContext, WaitResult, handle_input_event, read_input,
+    InterruptState, OutputState, PendingResponse, RenderContext, ScreenState, StreamRenderState,
+    ViewportState, WaitContext, WaitResult, handle_input_event, read_input,
 };
 use models::*;
 use render::{format_tools, render_markdown_for_console, show_file_output};
@@ -107,6 +108,7 @@ use session_store::*;
 use stats::*;
 use terminal::*;
 use wait::*;
+use workspace_tab::{TabAction, WorkspaceRing, WorkspaceTab};
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -118,6 +120,10 @@ struct Args {
     workspace: Option<PathBuf>,
     #[arg(short, long)]
     resume: Option<String>,
+    /// Reopen the workspace tabs that were open at the end of the last run
+    /// (saved in ~/.orangu/workspaces).
+    #[arg(short = 'a', long = "all")]
+    all: bool,
     /// Interactively create ~/.orangu/orangu.conf and exit.
     #[arg(short, long)]
     init: bool,
@@ -186,17 +192,6 @@ async fn run() -> Result<()> {
     };
     let config = load_client_configuration(&config_path)?;
     let quote_module = quotes::QuoteModule::from_str(&config.quotes);
-    let workspace = resolve_workspace_root(args.workspace)?;
-    let workspace_created = if !workspace.exists() {
-        std::fs::create_dir_all(&workspace)
-            .with_context(|| format!("Failed to create workspace {}", workspace.display()))?;
-        true
-    } else {
-        false
-    };
-    let tools = ToolExecutor::new(&workspace);
-    let skills = orangu::skills::SkillRegistry::discover(&workspace);
-
     // Remove any binary staged by a previous `/restart`; it is only needed
     // across the exec handoff and must not accumulate.
     clear_restart_dir();
@@ -217,56 +212,38 @@ async fn run() -> Result<()> {
     // server's resolved model and changed at runtime by `/model`.
     let mut active_model_id = startup_profile.model.clone();
     let mut active_model = startup_model.clone();
-    let mut session = ChatSession::new(&system_prompt_with_skills(
+    let mut current_endpoint = Some(startup_endpoint.clone());
+
+    // The system prompt is shared across workspace tabs (per-workspace model
+    // comes later), so it is resolved once and reused when opening tabs.
+    let system_prompt = system_prompt(
         config
             .llms
             .get(&active_model)
             .ok_or_else(|| anyhow!("missing configured server {}", active_model))?,
-        &skills,
-    ));
-    let mut current_endpoint = Some(startup_endpoint.clone());
+    )
+    .to_string();
 
-    let current_branch = workspace_branch_name(&workspace);
-
-    let (session_id, is_resumed) = match &args.resume {
-        Some(id) => (id.clone(), true),
-        None => {
-            let workspace_str = workspace.display().to_string();
-            match find_session_for_workspace_branch(
-                &workspace_str,
-                current_branch.as_deref().unwrap_or(""),
-            ) {
-                Some(existing_id) => (existing_id, true),
-                None => (Uuid::new_v4().to_string(), false),
+    // Open the first workspace tab (tab 1). Each tab is its own session; the
+    // ring holds the others as the user opens more with `/workspace`/Alt+Insert.
+    let initial_tab = WorkspaceTab::open(
+        resolve_workspace_root(args.workspace)?,
+        args.resume.as_deref(),
+        true,
+        &system_prompt,
+    )?;
+    let mut ring = WorkspaceRing::new();
+    // If -a/--all, reopen the workspace tabs that were open at the end of the
+    // last run. Skip paths that equal the initial workspace (already open) and
+    // silently ignore tabs whose directories have since been deleted.
+    if args.all {
+        for saved_workspace in load_open_workspaces() {
+            if saved_workspace != initial_tab.workspace
+                && let Ok(tab) = WorkspaceTab::open(saved_workspace, None, true, &system_prompt)
+            {
+                ring.park(tab);
             }
         }
-    };
-    let session_dir = session_dir_path(&session_id)?;
-    std::fs::create_dir_all(&session_dir).with_context(|| {
-        format!(
-            "failed to create session directory {}",
-            session_dir.display()
-        )
-    })?;
-    let session_hist_path = session_dir.join("history");
-    let session_messages_path = session_dir.join("messages");
-    let session_metadata_path = session_dir.join("metadata");
-
-    if !is_resumed {
-        save_session_metadata(
-            &session_metadata_path,
-            &SessionMetadata {
-                started_at: current_unix_timestamp(),
-                last_updated_at: current_unix_timestamp(),
-                workspace: workspace.display().to_string(),
-                branch: current_branch.clone().unwrap_or_default(),
-            },
-        )?;
-    }
-
-    if is_resumed {
-        let messages = load_session_messages(&session_messages_path)?;
-        session.restore(messages);
     }
 
     let _terminal_ui_guard = TerminalUiGuard::new()?;
@@ -274,36 +251,43 @@ async fn run() -> Result<()> {
     let vw = terminal_width();
     let vh = terminal_height();
     let mut viewport = ViewportState::new(config.width, vw, vh);
-    let mut output_state = OutputState::default();
     let mut interrupt_state = InterruptState::default();
     let mut input_state = InputState::default();
-    let mut pending_commands = VecDeque::new();
-    let mut usage_stats = UsageStats::new().with_session(&session_id);
-    let mut history = load_history(&session_hist_path)?;
     let mut restart_requested = false;
-    // The last `/review` summary and `/auto_review` report (Markdown), kept
-    // so `/comment <number> with [auto] review` can post them.
-    let mut last_review_report: Option<String> = None;
-    let mut last_auto_review_report: Option<String> = None;
-    // Whether the most recently produced report was the `/auto_review` one, so
-    // `/export review` exports the last review the user ran rather than always
-    // preferring one kind over the other.
-    let mut last_review_was_auto = false;
     // When set, the post-loop exec resumes this session instead of the current
     // one — used by `/session <UUID>` to switch sessions in place.
     let mut resume_override: Option<String> = None;
     // When set, the post-loop exec switches to this workspace directory (without
     // a resume target) — used by `/session <path>` to open a new workspace.
     let mut workspace_override: Option<PathBuf> = None;
-    let mut startup_notice_until: Option<std::time::Instant> =
-        if is_resumed && args.resume.is_none() {
-            Some(std::time::Instant::now() + std::time::Duration::from_secs(5))
-        } else {
-            None
-        };
-    if workspace_created {
-        output_state.push_text(&format!("Created workspace {}", workspace.display()));
-    }
+    // A pending workspace tab switch, applied at the top of the next iteration
+    // so it never races the active tab's borrows in the render context.
+    let mut pending_tab_action: Option<TabAction> = None;
+
+    // The active tab's live state lives in these locals, exactly as the single
+    // workspace did before tabs. A tab switch parks them in the ring and unpacks
+    // the target tab back into them (see `apply_tab_action!`).
+    let WorkspaceTab {
+        mut workspace,
+        mut tools,
+        mut skills,
+        mut session,
+        mut output_state,
+        mut pending_commands,
+        mut usage_stats,
+        mut history,
+        mut session_id,
+        mut session_dir,
+        mut session_hist_path,
+        mut session_messages_path,
+        mut session_metadata_path,
+        mut current_branch,
+        mut last_review_report,
+        mut last_auto_review_report,
+        mut last_review_was_auto,
+        mut startup_notice_until,
+        mut pending_response,
+    } = initial_tab;
 
     // If the active server isn't serving the configured model at startup, switch
     // to a model it does advertise.
@@ -345,7 +329,173 @@ async fn run() -> Result<()> {
         tokio::task::spawn_blocking(move || fetch_issue_metadata(&meta_workspace, forge))
     });
 
+    // Workspace tab switching. `current_tab!()` packs the active tab's locals
+    // into a `WorkspaceTab` (moving them out); `load_tab!(t)` unpacks one back
+    // into them; `apply_tab_action!` parks the active tab in the ring and makes
+    // another active. The macros close over the run-loop locals by definition
+    // site, so the loop body keeps using those locals unchanged.
+    macro_rules! current_tab {
+        () => {
+            WorkspaceTab {
+                workspace,
+                tools,
+                skills,
+                session,
+                output_state,
+                pending_commands,
+                usage_stats,
+                history,
+                session_id,
+                session_dir,
+                session_hist_path,
+                session_messages_path,
+                session_metadata_path,
+                current_branch,
+                last_review_report,
+                last_auto_review_report,
+                last_review_was_auto,
+                startup_notice_until,
+                pending_response,
+            }
+        };
+    }
+    macro_rules! load_tab {
+        ($tab:expr) => {{
+            let tab = $tab;
+            workspace = tab.workspace;
+            tools = tab.tools;
+            skills = tab.skills;
+            session = tab.session;
+            output_state = tab.output_state;
+            pending_commands = tab.pending_commands;
+            usage_stats = tab.usage_stats;
+            history = tab.history;
+            session_id = tab.session_id;
+            session_dir = tab.session_dir;
+            session_hist_path = tab.session_hist_path;
+            session_messages_path = tab.session_messages_path;
+            session_metadata_path = tab.session_metadata_path;
+            current_branch = tab.current_branch;
+            last_review_report = tab.last_review_report;
+            last_auto_review_report = tab.last_auto_review_report;
+            last_review_was_auto = tab.last_review_was_auto;
+            startup_notice_until = tab.startup_notice_until;
+            pending_response = tab.pending_response;
+        }};
+    }
+    macro_rules! apply_tab_action {
+        ($action:expr) => {{
+            match $action {
+                TabAction::Next => {
+                    let target = ring.rotate(current_tab!(), 1);
+                    load_tab!(target);
+                }
+                TabAction::Previous => {
+                    let target = ring.rotate(current_tab!(), -1);
+                    load_tab!(target);
+                }
+                TabAction::SwitchTo(index) => {
+                    if index >= ring.total() {
+                        output_state.push_text(&format!("No workspace {} is open.", index + 1));
+                    } else {
+                        let target = ring.switch_to(current_tab!(), index);
+                        load_tab!(target);
+                    }
+                }
+                TabAction::Open(path) => {
+                    if let Some(index) = ring.position_of(&workspace, &path) {
+                        let target = ring.switch_to(current_tab!(), index);
+                        load_tab!(target);
+                    } else {
+                        match WorkspaceTab::open(path, None, true, &system_prompt) {
+                            Ok(new_tab) => {
+                                let target = ring.open(current_tab!(), new_tab);
+                                load_tab!(target);
+                            }
+                            Err(err) => output_state.push_text(&format!("Error: {err:#}")),
+                        }
+                    }
+                }
+                TabAction::New => {
+                    // A fresh tab on the active workspace's directory, with its
+                    // own new session; the user re-points it with `/workspace`.
+                    match WorkspaceTab::open(workspace.clone(), None, false, &system_prompt) {
+                        Ok(new_tab) => {
+                            let target = ring.open(current_tab!(), new_tab);
+                            load_tab!(target);
+                        }
+                        Err(err) => output_state.push_text(&format!("Error: {err:#}")),
+                    }
+                }
+                TabAction::Close => {
+                    if ring.total() == 1 {
+                        output_state.push_text("Only /quit exits orangu.");
+                    } else {
+                        let parked = current_tab!();
+                        let _ = parked.save();
+                        // `total > 1` guarantees a neighbour to focus.
+                        let target = ring.close(parked).expect("more than one tab is open");
+                        load_tab!(target);
+                    }
+                }
+            }
+            output_state.reset_scroll();
+        }};
+    }
+    // Persist every open tab on exit so each one stays resumable — the active
+    // tab from its locals, plus every parked tab in the ring. Also record the
+    // open workspace paths so `orangu -a` can restore the layout next time.
+    macro_rules! save_all_tabs {
+        () => {{
+            save_session_messages(&session_messages_path, session.messages())?;
+            update_session_metadata_timestamp(&session_metadata_path)?;
+            for tab in ring.parked() {
+                let _ = tab.save();
+            }
+            {
+                let mut all_workspaces = vec![workspace.clone()];
+                all_workspaces.extend(ring.parked().iter().map(|t| t.workspace.clone()));
+                save_open_workspaces(&all_workspaces);
+            }
+        }};
+    }
+
     loop {
+        // Apply a pending tab switch before anything borrows the active tab's
+        // locals this iteration (the render context below borrows `tools`).
+        if let Some(action) = pending_tab_action.take() {
+            apply_tab_action!(action);
+        }
+
+        let tab_bar = (ring.total() > 1).then(|| WorkspaceTabsView {
+            count: ring.total(),
+            active: ring.active_pos(),
+            placement: config.workspaces,
+        });
+        // Per-tab colored dots: only computed when feedback is on and multiple
+        // tabs are open. Indexed left-to-right; parked tabs check whether their
+        // recorded branch is still the workspace's live branch.
+        let tab_statuses: Vec<TabStatus> = if config.feedback && ring.total() > 1 {
+            let active_pos = ring.active_pos();
+            (0..ring.total())
+                .map(|pos| {
+                    if pos == active_pos {
+                        TabStatus::Valid
+                    } else {
+                        let others_idx = if pos < active_pos { pos } else { pos - 1 };
+                        parked_tab_status(&ring.parked()[others_idx])
+                    }
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+        // Pre-compute the variant used during any wait (local command, streaming
+        // or LLM response): the active tab's dot becomes white-blinking.
+        let mut tab_statuses_working = tab_statuses.clone();
+        if let Some(s) = tab_statuses_working.get_mut(ring.active_pos()) {
+            *s = TabStatus::Working;
+        }
         let prompt_branch = workspace_branch_name(tools.workspace());
         let active_profile = config
             .llms
@@ -372,9 +522,10 @@ async fn run() -> Result<()> {
             output_state.push_text(&format!("Switched model from {old_model} to {new_model}"));
             header_status.model_ok = true;
         }
+        let endpoint = current_endpoint.as_deref().unwrap_or("(disconnected)");
         let render = RenderContext {
             current_model: &active_model_id,
-            endpoint: current_endpoint.as_deref().unwrap_or("(disconnected)"),
+            endpoint,
             workspace: tools.workspace(),
             prompt_branch: prompt_branch.as_deref(),
             header_status,
@@ -387,7 +538,117 @@ async fn run() -> Result<()> {
             server_names: &server_names,
             available_models: &available_models,
             skills: &skills,
+            tab_bar,
+            tab_statuses: &tab_statuses,
         };
+
+        // If the active tab has a background streaming task, re-attach to it
+        // so the user sees live output and stats, then continue to the next
+        // loop iteration (which will re-run the normal prompt-read path).
+        if let Some(pr) = pending_response.take() {
+            let pr_llm_start = pr.llm_start;
+            let pr_tool_time_before = pr.tool_time_before;
+            let prompt_profile = config
+                .llms
+                .get(&active_model)
+                .cloned()
+                .ok_or_else(|| anyhow!("missing configured server {}", active_model))?;
+            let mut deferred_tab_during_wait: Option<TabAction> = None;
+            let pr_result = wait_for_pending_response(
+                &mut session,
+                &prompt_profile,
+                pr,
+                WaitContext {
+                    render: RenderContext {
+                        current_model: &active_model_id,
+                        endpoint: current_endpoint.as_deref().unwrap_or("(disconnected)"),
+                        workspace: tools.workspace(),
+                        prompt_branch: prompt_branch.as_deref(),
+                        header_status,
+                        virtual_width: viewport.virtual_width,
+                        actual_width: viewport.actual_width,
+                        actual_height: viewport.actual_height,
+                        x_offset: viewport.x_offset,
+                        banner: config.banner,
+                        feedback: config.feedback,
+                        server_names: &server_names,
+                        available_models: &available_models,
+                        skills: &skills,
+                        tab_bar,
+                        tab_statuses: &tab_statuses_working,
+                    },
+                    history: &mut history,
+                    history_path: &session_hist_path,
+                    server_names: &server_names,
+                    available_models: &available_models,
+                    interrupt_state: &mut interrupt_state,
+                    output_state: &mut output_state,
+                    input_state: &mut input_state,
+                    pending_commands: &mut pending_commands,
+                    thinking_quote: None,
+                    viewport: &mut viewport,
+                    skills: &skills,
+                    deferred_tab: &mut deferred_tab_during_wait,
+                },
+            )
+            .await;
+            match pr_result {
+                Ok(WaitResult::Response(answer)) => {
+                    let tool_delta = tools
+                        .total_tool_duration()
+                        .saturating_sub(pr_tool_time_before);
+                    usage_stats.record_response(pr_llm_start.elapsed(), &answer, tool_delta);
+                    output_state.push_markdown(&answer);
+                    if config.feedback {
+                        output_state.push_text(FEEDBACK_OK);
+                    }
+                }
+                Ok(WaitResult::Cancelled(partial_output)) => {
+                    let tool_delta = tools
+                        .total_tool_duration()
+                        .saturating_sub(pr_tool_time_before);
+                    usage_stats.record_response(
+                        pr_llm_start.elapsed(),
+                        &partial_output,
+                        tool_delta,
+                    );
+                    preserve_cancelled_output(&mut output_state, &partial_output);
+                }
+                Ok(WaitResult::Failed { partial, error }) => {
+                    let tool_delta = tools
+                        .total_tool_duration()
+                        .saturating_sub(pr_tool_time_before);
+                    usage_stats.record_response(pr_llm_start.elapsed(), &partial, tool_delta);
+                    output_state.push_text(&format!("Error: {error:#}"));
+                    if config.feedback {
+                        output_state.push_text(FEEDBACK_ERR);
+                    }
+                }
+                Ok(WaitResult::BackgroundStreaming(new_pr)) => {
+                    pending_response = Some(new_pr);
+                }
+                Ok(WaitResult::Quit) => {
+                    save_all_tabs!();
+                    print!("{CLEAR_TERMINAL_SEQUENCE}");
+                    std::io::stdout().flush()?;
+                    break;
+                }
+                Err(err) => {
+                    let tool_delta = tools
+                        .total_tool_duration()
+                        .saturating_sub(pr_tool_time_before);
+                    usage_stats.record_elapsed(pr_llm_start.elapsed(), tool_delta);
+                    output_state.push_text(&format!("Error: {err:#}"));
+                    if config.feedback {
+                        output_state.push_text(FEEDBACK_ERR);
+                    }
+                }
+            }
+            pending_tab_action = deferred_tab_during_wait;
+            output_state.reset_scroll();
+            continue;
+        }
+
         // Collect the startup branch-sync result once its task finishes.
         if sync_handle
             .as_ref()
@@ -509,9 +770,24 @@ async fn run() -> Result<()> {
                     trimmed
                 }
                 InputResult::Refresh => continue,
+                InputResult::WorkspacePrevious => {
+                    pending_tab_action = Some(TabAction::Previous);
+                    continue;
+                }
+                InputResult::WorkspaceNext => {
+                    pending_tab_action = Some(TabAction::Next);
+                    continue;
+                }
+                InputResult::WorkspaceNew => {
+                    pending_tab_action = Some(TabAction::New);
+                    continue;
+                }
+                InputResult::WorkspaceClose => {
+                    pending_tab_action = Some(TabAction::Close);
+                    continue;
+                }
                 InputResult::Quit => {
-                    save_session_messages(&session_messages_path, session.messages())?;
-                    update_session_metadata_timestamp(&session_metadata_path)?;
+                    save_all_tabs!();
                     print!("{CLEAR_TERMINAL_SEQUENCE}");
                     std::io::stdout().flush()?;
                     break;
@@ -585,23 +861,20 @@ async fn run() -> Result<()> {
         }
         match command_outcome {
             CommandOutcome::Quit => {
-                save_session_messages(&session_messages_path, session.messages())?;
-                update_session_metadata_timestamp(&session_metadata_path)?;
+                save_all_tabs!();
                 print!("{CLEAR_TERMINAL_SEQUENCE}");
                 std::io::stdout().flush()?;
                 break;
             }
             CommandOutcome::Restart => {
-                save_session_messages(&session_messages_path, session.messages())?;
-                update_session_metadata_timestamp(&session_metadata_path)?;
+                save_all_tabs!();
                 print!("{CLEAR_TERMINAL_SEQUENCE}");
                 std::io::stdout().flush()?;
                 restart_requested = true;
                 break;
             }
             CommandOutcome::SwitchSession(target) => {
-                save_session_messages(&session_messages_path, session.messages())?;
-                update_session_metadata_timestamp(&session_metadata_path)?;
+                save_all_tabs!();
                 print!("{CLEAR_TERMINAL_SEQUENCE}");
                 std::io::stdout().flush()?;
                 restart_requested = true;
@@ -609,13 +882,20 @@ async fn run() -> Result<()> {
                 break;
             }
             CommandOutcome::SwitchWorkspace(dir) => {
-                save_session_messages(&session_messages_path, session.messages())?;
-                update_session_metadata_timestamp(&session_metadata_path)?;
+                save_all_tabs!();
                 print!("{CLEAR_TERMINAL_SEQUENCE}");
                 std::io::stdout().flush()?;
                 restart_requested = true;
                 workspace_override = Some(dir);
                 break;
+            }
+            CommandOutcome::SwitchWorkspaceTab(index) => {
+                pending_tab_action = Some(TabAction::SwitchTo(index));
+                continue;
+            }
+            CommandOutcome::OpenWorkspaceTab(dir) => {
+                pending_tab_action = Some(TabAction::Open(dir));
+                continue;
             }
             CommandOutcome::Quiet => {
                 if config.feedback {
@@ -677,7 +957,10 @@ async fn run() -> Result<()> {
                     server_names: &server_names,
                     available_models: &available_models,
                     skills: &skills,
+                    tab_bar,
+                    tab_statuses: &tab_statuses_working,
                 };
+                let mut deferred_tab_during_wait: Option<TabAction> = None;
                 let result = wait_for_local_command(
                     WaitContext {
                         render: blocking_render,
@@ -692,6 +975,7 @@ async fn run() -> Result<()> {
                         thinking_quote: None,
                         viewport: &mut viewport,
                         skills: &skills,
+                        deferred_tab: &mut deferred_tab_during_wait,
                     },
                     handle,
                 )
@@ -710,6 +994,7 @@ async fn run() -> Result<()> {
                         }
                     }
                 }
+                pending_tab_action = deferred_tab_during_wait;
                 output_state.reset_scroll();
                 continue;
             }
@@ -732,7 +1017,10 @@ async fn run() -> Result<()> {
                     server_names: &server_names,
                     available_models: &available_models,
                     skills: &skills,
+                    tab_bar,
+                    tab_statuses: &tab_statuses_working,
                 };
+                let mut deferred_tab_during_wait: Option<TabAction> = None;
                 let result = wait_for_streaming_command(
                     WaitContext {
                         render: blocking_render,
@@ -747,6 +1035,7 @@ async fn run() -> Result<()> {
                         thinking_quote: None,
                         viewport: &mut viewport,
                         skills: &skills,
+                        deferred_tab: &mut deferred_tab_during_wait,
                     },
                     handle,
                     &mut rx,
@@ -765,6 +1054,7 @@ async fn run() -> Result<()> {
                         }
                     }
                 }
+                pending_tab_action = deferred_tab_during_wait;
                 output_state.reset_scroll();
                 continue;
             }
@@ -960,6 +1250,7 @@ async fn run() -> Result<()> {
                 }
                 // The modal view overwrote the screen; the next loop iteration
                 // redraws the normal interface from the top.
+                pending_tab_action = state.pending_tab;
                 output_state.reset_scroll();
                 continue;
             }
@@ -1060,11 +1351,14 @@ async fn run() -> Result<()> {
             .unwrap_or_default()
             .as_secs();
         let thinking_quote = quote_module.pick(seed);
+        let mut deferred_tab_during_wait: Option<TabAction> = None;
         match wait_for_response(
             &mut session,
             &prompt_input,
             &prompt_profile,
             &tools,
+            llm_start,
+            tool_time_before,
             WaitContext {
                 render: RenderContext {
                     current_model: &active_model_id,
@@ -1081,6 +1375,8 @@ async fn run() -> Result<()> {
                     server_names: &server_names,
                     available_models: &available_models,
                     skills: &skills,
+                    tab_bar,
+                    tab_statuses: &tab_statuses_working,
                 },
                 history: &mut history,
                 history_path: &session_hist_path,
@@ -1093,6 +1389,7 @@ async fn run() -> Result<()> {
                 thinking_quote,
                 viewport: &mut viewport,
                 skills: &skills,
+                deferred_tab: &mut deferred_tab_during_wait,
             },
         )
         .await
@@ -1119,11 +1416,13 @@ async fn run() -> Result<()> {
                 }
             }
             Ok(WaitResult::Quit) => {
-                save_session_messages(&session_messages_path, session.messages())?;
-                update_session_metadata_timestamp(&session_metadata_path)?;
+                save_all_tabs!();
                 print!("{CLEAR_TERMINAL_SEQUENCE}");
                 std::io::stdout().flush()?;
                 break;
+            }
+            Ok(WaitResult::BackgroundStreaming(pr)) => {
+                pending_response = Some(pr);
             }
             Err(err) => {
                 let tool_delta = tools.total_tool_duration().saturating_sub(tool_time_before);
@@ -1134,6 +1433,7 @@ async fn run() -> Result<()> {
                 }
             }
         }
+        pending_tab_action = deferred_tab_during_wait;
         output_state.reset_scroll();
     }
 
@@ -1186,13 +1486,32 @@ async fn run() -> Result<()> {
         }
     }
 
-    if usage_stats.total_tokens == 0 && is_ephemeral_branch(current_branch.as_deref().unwrap_or(""))
-    {
-        delete_session_dir(&session_dir);
-    } else {
-        eprintln!("orangu --resume {session_id}");
+    // Finish every open tab: print one resume line per tab (with its workspace
+    // and branch), or clean up its session if it was ephemeral.
+    let active_tab = current_tab!();
+    active_tab.finish();
+    for tab in ring.parked() {
+        tab.finish();
     }
     Ok(())
+}
+
+/// Determine the feedback-dot status of a parked (non-active) workspace tab.
+/// Checks whether the tab's recorded branch is still the workspace's live
+/// branch; a mismatch signals that the branch was deleted or merged.
+fn parked_tab_status(tab: &WorkspaceTab) -> TabStatus {
+    if tab.pending_response.is_some() {
+        return TabStatus::Working;
+    }
+    if !tab.workspace.is_dir() {
+        return TabStatus::BranchGone;
+    }
+    if let Some(recorded) = &tab.current_branch
+        && workspace_branch_name(&tab.workspace).as_deref() != Some(recorded.as_str())
+    {
+        return TabStatus::BranchGone;
+    }
+    TabStatus::Valid
 }
 
 fn llm_prompt_block_reason(

--- a/src/bin/orangu/review/auto.rs
+++ b/src/bin/orangu/review/auto.rs
@@ -438,6 +438,9 @@ pub(crate) struct AutoReviewState {
     pub(crate) reject: Option<AutoReviewReject>,
     /// The model performing the review, shown after the `Conclusion` verdict.
     pub(crate) model: String,
+    /// A workspace-switch key pressed during streaming; applied by `main` after
+    /// the auto review mode exits.
+    pub(crate) pending_tab: Option<crate::workspace_tab::TabAction>,
 }
 
 impl AutoReviewState {
@@ -461,6 +464,7 @@ impl AutoReviewState {
             cancelled: false,
             reject: None,
             model: String::new(),
+            pending_tab: None,
         }
     }
 
@@ -1615,6 +1619,10 @@ pub(crate) async fn run_auto_review_mode(
                     exit_requested = true;
                     break 'auto;
                 }
+                AutoReviewRequestOutcome::SwitchTab(tab) => {
+                    state.pending_tab = Some(tab);
+                    break 'auto;
+                }
             }
         }
         // Mark the file: red when any category rejected, white when a request
@@ -1664,6 +1672,9 @@ pub(crate) async fn run_auto_review_mode(
             }
             AutoReviewRequestOutcome::Cancelled => state.cancel(),
             AutoReviewRequestOutcome::Exit => exit_requested = true,
+            AutoReviewRequestOutcome::SwitchTab(tab) => {
+                state.pending_tab = Some(tab);
+            }
         }
     }
     // When feedback is on, announce a completed run with the standard terminal
@@ -1806,6 +1817,9 @@ pub(crate) enum AutoReviewRequestOutcome {
     Cancelled,
     /// The user pressed Alt+x — leave auto review mode entirely.
     Exit,
+    /// The user pressed a workspace-switch key (Alt+,/./Insert/Delete) —
+    /// cancel the current request and leave auto review to perform the switch.
+    SwitchTab(crate::workspace_tab::TabAction),
 }
 
 /// Drive one auto review request, rendering the screen with a live status
@@ -1885,6 +1899,30 @@ pub(crate) async fn run_auto_review_request(
                         (KeyCode::Char('x'), true) => {
                             drop(future);
                             return Ok(AutoReviewRequestOutcome::Exit);
+                        }
+                        (KeyCode::Char(','), true) => {
+                            drop(future);
+                            return Ok(AutoReviewRequestOutcome::SwitchTab(
+                                crate::workspace_tab::TabAction::Previous,
+                            ));
+                        }
+                        (KeyCode::Char('.'), true) => {
+                            drop(future);
+                            return Ok(AutoReviewRequestOutcome::SwitchTab(
+                                crate::workspace_tab::TabAction::Next,
+                            ));
+                        }
+                        (KeyCode::Insert, true) => {
+                            drop(future);
+                            return Ok(AutoReviewRequestOutcome::SwitchTab(
+                                crate::workspace_tab::TabAction::New,
+                            ));
+                        }
+                        (KeyCode::Delete, true) => {
+                            drop(future);
+                            return Ok(AutoReviewRequestOutcome::SwitchTab(
+                                crate::workspace_tab::TabAction::Close,
+                            ));
                         }
                         (KeyCode::Up, _) => state.scroll = state.scroll.saturating_sub(1),
                         (KeyCode::Down, _) => state.scroll = state.scroll.saturating_add(1),

--- a/src/bin/orangu/session_store.rs
+++ b/src/bin/orangu/session_store.rs
@@ -39,6 +39,122 @@ pub(crate) fn clear_restart_dir() {
     }
 }
 
+/// File recording the workspace directories open in the last run, one per line.
+/// Written on exit and read by `orangu -a|--all` to reopen those tabs.
+pub(crate) const OPEN_WORKSPACES_FILE: &str = ".orangu/workspaces";
+
+fn open_workspaces_path() -> Option<PathBuf> {
+    Some(home::home_dir()?.join(OPEN_WORKSPACES_FILE))
+}
+
+/// Record the open workspace directories, one per line, so `orangu -a` can
+/// reopen them next time. Errors are ignored: failing to save the layout must
+/// never block exit.
+pub(crate) fn save_open_workspaces(workspaces: &[PathBuf]) {
+    let Some(path) = open_workspaces_path() else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&path, format_workspace_paths(workspaces));
+}
+
+fn format_workspace_paths(workspaces: &[PathBuf]) -> String {
+    use std::fmt::Write as FmtWrite;
+    let mut body = String::new();
+    for (i, workspace) in workspaces.iter().enumerate() {
+        if i > 0 {
+            body.push('\n');
+        }
+        write!(body, "{}", workspace.display()).ok();
+    }
+    body
+}
+
+/// The workspace directories saved by the last run that still exist, in order.
+/// Read by `orangu -a|--all`; missing directories are skipped so a deleted
+/// project does not get recreated on restore.
+pub(crate) fn load_open_workspaces() -> Vec<PathBuf> {
+    let Some(path) = open_workspaces_path() else {
+        return Vec::new();
+    };
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    parse_workspace_paths(&contents)
+        .into_iter()
+        .filter(|workspace| workspace.is_dir())
+        .collect()
+}
+
+fn parse_workspace_paths(contents: &str) -> Vec<PathBuf> {
+    contents
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(PathBuf::from)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_workspace_paths_joins_with_newlines() {
+        let paths = vec![
+            PathBuf::from("/home/user/project"),
+            PathBuf::from("/home/user/other"),
+        ];
+        let body = format_workspace_paths(&paths);
+        assert_eq!(body, "/home/user/project\n/home/user/other");
+    }
+
+    #[test]
+    fn format_workspace_paths_single_entry_has_no_trailing_newline() {
+        let paths = vec![PathBuf::from("/a")];
+        assert_eq!(format_workspace_paths(&paths), "/a");
+    }
+
+    #[test]
+    fn format_workspace_paths_empty_produces_empty_string() {
+        assert_eq!(format_workspace_paths(&[]), "");
+    }
+
+    #[test]
+    fn parse_workspace_paths_splits_lines() {
+        let body = "/home/user/project\n/home/user/other";
+        let paths = parse_workspace_paths(body);
+        assert_eq!(
+            paths,
+            [
+                PathBuf::from("/home/user/project"),
+                PathBuf::from("/home/user/other"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_workspace_paths_skips_blank_lines() {
+        let body = "/a\n\n  \n/b";
+        let paths = parse_workspace_paths(body);
+        assert_eq!(paths, [PathBuf::from("/a"), PathBuf::from("/b")]);
+    }
+
+    #[test]
+    fn format_and_parse_round_trip() {
+        let original = vec![
+            PathBuf::from("/workspace/alpha"),
+            PathBuf::from("/workspace/beta"),
+            PathBuf::from("/workspace/gamma"),
+        ];
+        let serialized = format_workspace_paths(&original);
+        let parsed = parse_workspace_paths(&serialized);
+        assert_eq!(parsed, original);
+    }
+}
+
 /// Resolve the path to exec when restarting.
 ///
 /// `std::env::current_exe()` reads `/proc/self/exe`, which keeps pointing at the

--- a/src/bin/orangu/terminal.rs
+++ b/src/bin/orangu/terminal.rs
@@ -118,6 +118,8 @@ pub fn print_screen(render: RenderContext<'_>, screen: ScreenState<'_>) {
             prompt_branch: render.prompt_branch,
             status: render.header_status,
             banner: render.banner,
+            tab_bar: render.tab_bar,
+            tab_statuses: render.tab_statuses,
             transcript: screen.transcript,
             scroll_offset: screen.scroll_offset,
             left_status: screen.left_status,

--- a/src/bin/orangu/test_support.rs
+++ b/src/bin/orangu/test_support.rs
@@ -60,6 +60,9 @@ pub(crate) fn test_input_context<'a>(workspace: &'a std::path::Path) -> InputCon
             available_models: &[],
             skills: SKILLS
                 .get_or_init(|| orangu::skills::SkillRegistry::discover(std::path::Path::new("/"))),
+            // Tests run with a single workspace; no tab bar or status dots needed.
+            tab_bar: None,
+            tab_statuses: &[],
         },
         skills: SKILLS
             .get_or_init(|| orangu::skills::SkillRegistry::discover(std::path::Path::new("/"))),

--- a/src/bin/orangu/wait.rs
+++ b/src/bin/orangu/wait.rs
@@ -25,8 +25,99 @@ pub(crate) async fn wait_for_response(
     user_input: &str,
     profile: &LlmConfiguration,
     tools: &ToolExecutor,
+    llm_start: std::time::Instant,
+    tool_time_before: std::time::Duration,
     wait_context: WaitContext<'_>,
 ) -> Result<WaitResult> {
+    // Snapshot messages so we can restore a clean session on ESC-cancel.
+    let saved_messages = session.messages().to_vec();
+
+    // Move `session` into the background task so the future can outlive this
+    // stack frame if the user switches tabs mid-stream.
+    let real_session = std::mem::replace(session, ChatSession::new(""));
+    let user_input_owned = user_input.to_string();
+    let profile_owned = profile.clone();
+    let tools_clone = tools.clone();
+    let streamed_state = Arc::new(Mutex::new(StreamRenderState::default()));
+    let so = Arc::clone(&streamed_state);
+    let sm = Arc::clone(&streamed_state);
+    let st = Arc::clone(&streamed_state);
+
+    let handle = tokio::spawn(async move {
+        let mut s = real_session;
+        let result = s
+            .prompt(
+                &user_input_owned,
+                &profile_owned,
+                &tools_clone,
+                move |delta| {
+                    if let Ok(mut state) = so.lock() {
+                        state.output.push_str(delta);
+                    }
+                },
+                move |metrics| {
+                    if let Ok(mut state) = sm.lock() {
+                        state.metrics.merge(metrics);
+                    }
+                },
+                move |running| {
+                    if let Ok(mut state) = st.lock() {
+                        state.tool_running_since = if running {
+                            Some(std::time::Instant::now())
+                        } else {
+                            None
+                        };
+                    }
+                },
+            )
+            .await;
+        (s, result)
+    });
+
+    drive_handle(
+        session,
+        PendingResponse {
+            stream_state: streamed_state,
+            handle,
+            llm_start,
+            tool_time_before,
+            saved_messages,
+        },
+        profile,
+        wait_context,
+    )
+    .await
+}
+
+/// Re-attach to an LLM response that was running in the background while the
+/// user was on another tab. Behaves like [`wait_for_response`] but reuses the
+/// already-running task instead of starting a new one.
+pub(crate) async fn wait_for_pending_response(
+    session: &mut ChatSession,
+    profile: &LlmConfiguration,
+    pr: PendingResponse,
+    wait_context: WaitContext<'_>,
+) -> Result<WaitResult> {
+    drive_handle(session, pr, profile, wait_context).await
+}
+
+/// The shared polling loop used by both [`wait_for_response`] and
+/// [`wait_for_pending_response`]. Takes ownership of `pr` so the handle and
+/// streamed state can be moved into a [`WaitResult::BackgroundStreaming`]
+/// payload on a tab-switch without cloning.
+async fn drive_handle(
+    session: &mut ChatSession,
+    pr: PendingResponse,
+    profile: &LlmConfiguration,
+    wait_context: WaitContext<'_>,
+) -> Result<WaitResult> {
+    let PendingResponse {
+        stream_state: streamed_state,
+        handle,
+        llm_start,
+        tool_time_before,
+        saved_messages,
+    } = pr;
     let WaitContext {
         mut render,
         history,
@@ -40,36 +131,11 @@ pub(crate) async fn wait_for_response(
         thinking_quote,
         viewport,
         skills,
+        deferred_tab,
     } = wait_context;
-    let streamed_state = Arc::new(Mutex::new(StreamRenderState::default()));
-    let prompt_output = Arc::clone(&streamed_state);
-    let prompt_metrics = Arc::clone(&streamed_state);
-    let prompt_tool_running = Arc::clone(&streamed_state);
+
+    let mut handle = handle;
     let tokenizer = cl100k_base().ok();
-    let mut prompt_future = Box::pin(session.prompt(
-        user_input,
-        profile,
-        tools,
-        move |delta| {
-            if let Ok(mut state) = prompt_output.lock() {
-                state.output.push_str(delta);
-            }
-        },
-        move |metrics| {
-            if let Ok(mut state) = prompt_metrics.lock() {
-                state.metrics.merge(metrics);
-            }
-        },
-        move |running| {
-            if let Ok(mut state) = prompt_tool_running.lock() {
-                state.tool_running_since = if running {
-                    Some(std::time::Instant::now())
-                } else {
-                    None
-                };
-            }
-        },
-    ));
     let mut interval = tokio::time::interval(WAIT_LOOP_POLL_INTERVAL);
     let mut thinking_frame = 0usize;
     let thinking_started = std::time::Instant::now();
@@ -100,9 +166,10 @@ pub(crate) async fn wait_for_response(
 
     loop {
         tokio::select! {
-            result = &mut prompt_future => {
-                let response = match result {
-                    Ok(response) => response,
+            task_result = &mut handle => {
+                let (real_session_back, llm_result) = task_result?;
+                *session = real_session_back;
+                match llm_result {
                     Err(error) => {
                         let partial = streamed_state
                             .lock()
@@ -110,30 +177,33 @@ pub(crate) async fn wait_for_response(
                             .unwrap_or_default();
                         return Ok(WaitResult::Failed { partial, error });
                     }
-                };
-                let final_state = streamed_state
-                    .lock()
-                    .map(|state| state.clone())
-                    .unwrap_or_default();
-                if let Some(pending_line) = final_pending_line(&final_state.output, &response)
-                    .map(|line| render_markdown_for_console(&line))
-                {
-                    print_screen(
-                        render,
-                        ScreenState {
-                            transcript: output_state.lines(),
-                            scroll_offset: output_state.scroll_offset(),
-                            left_status: None,
-                            pending_count: pending_commands.len(),
-                            pending_line: Some(pending_line.as_str()),
-                            input: input_state.as_str(),
-                            cursor: input_state.cursor(),
-            ghost_index: input_state.ghost_index,
-                        },
-                    );
-                    std::io::stdout().flush()?;
+                    Ok(response) => {
+                        let final_state = streamed_state
+                            .lock()
+                            .map(|state| state.clone())
+                            .unwrap_or_default();
+                        if let Some(pending_line) =
+                            final_pending_line(&final_state.output, &response)
+                                .map(|line| render_markdown_for_console(&line))
+                        {
+                            print_screen(
+                                render,
+                                ScreenState {
+                                    transcript: output_state.lines(),
+                                    scroll_offset: output_state.scroll_offset(),
+                                    left_status: None,
+                                    pending_count: pending_commands.len(),
+                                    pending_line: Some(pending_line.as_str()),
+                                    input: input_state.as_str(),
+                                    cursor: input_state.cursor(),
+                                    ghost_index: input_state.ghost_index,
+                                },
+                            );
+                            std::io::stdout().flush()?;
+                        }
+                        return Ok(WaitResult::Response(response));
+                    }
                 }
-                return Ok(WaitResult::Response(response));
             }
             _ = interval.tick() => {
                 let elapsed = thinking_started.elapsed();
@@ -159,7 +229,10 @@ pub(crate) async fn wait_for_response(
                                 .lock()
                                 .map(|state| state.output.clone())
                                 .unwrap_or_default();
-                            drop(prompt_future);
+                            handle.abort();
+                            let mut restored = ChatSession::new("");
+                            restored.restore(saved_messages);
+                            *session = restored;
                             return Ok(WaitResult::Cancelled(partial_output));
                         }
                         continue;
@@ -224,6 +297,26 @@ pub(crate) async fn wait_for_response(
                             }
                             InputResult::Refresh => {}
                             InputResult::Quit => return Ok(WaitResult::Quit),
+                            // Park the stream in a background task and switch tabs;
+                            // the LLM keeps running while the user works elsewhere.
+                            outcome @ (InputResult::WorkspacePrevious
+                            | InputResult::WorkspaceNext
+                            | InputResult::WorkspaceNew
+                            | InputResult::WorkspaceClose) => {
+                                *deferred_tab = Some(match outcome {
+                                    InputResult::WorkspacePrevious => crate::workspace_tab::TabAction::Previous,
+                                    InputResult::WorkspaceNext => crate::workspace_tab::TabAction::Next,
+                                    InputResult::WorkspaceNew => crate::workspace_tab::TabAction::New,
+                                    _ => crate::workspace_tab::TabAction::Close,
+                                });
+                                return Ok(WaitResult::BackgroundStreaming(PendingResponse {
+                                    stream_state: streamed_state,
+                                    handle,
+                                    llm_start,
+                                    tool_time_before,
+                                    saved_messages,
+                                }));
+                            }
                         }
                     }
                     redraw |= result.redraw;
@@ -257,7 +350,7 @@ pub(crate) async fn wait_for_response(
                             pending_line: Some(pending_line.as_str()),
                             input: input_state.as_str(),
                             cursor: input_state.cursor(),
-            ghost_index: input_state.ghost_index,
+                            ghost_index: input_state.ghost_index,
                         },
                     );
                     std::io::stdout().flush()?;
@@ -284,6 +377,7 @@ pub(crate) async fn wait_for_local_command(
         thinking_quote: _,
         viewport,
         skills,
+        deferred_tab,
     } = wait_context;
     let started = std::time::Instant::now();
     let mut interval = tokio::time::interval(WAIT_LOOP_POLL_INTERVAL);
@@ -300,7 +394,7 @@ pub(crate) async fn wait_for_local_command(
                     frame = next_frame;
                 }
                 while event::poll(std::time::Duration::ZERO)? {
-                    handle_input_event(
+                    let result = handle_input_event(
                         event::read()?,
                         input_state,
                         interrupt_state,
@@ -315,6 +409,20 @@ pub(crate) async fn wait_for_local_command(
                             skills,
                         },
                     );
+                    if let Some(
+                        outcome @ (InputResult::WorkspacePrevious
+                        | InputResult::WorkspaceNext
+                        | InputResult::WorkspaceNew
+                        | InputResult::WorkspaceClose),
+                    ) = result.outcome
+                    {
+                        *deferred_tab = Some(match outcome {
+                            InputResult::WorkspacePrevious => crate::workspace_tab::TabAction::Previous,
+                            InputResult::WorkspaceNext => crate::workspace_tab::TabAction::Next,
+                            InputResult::WorkspaceNew => crate::workspace_tab::TabAction::New,
+                            _ => crate::workspace_tab::TabAction::Close,
+                        });
+                    }
                     render.actual_width = viewport.actual_width;
                     render.actual_height = viewport.actual_height;
                     render.x_offset = viewport.x_offset;
@@ -359,6 +467,7 @@ pub(crate) async fn wait_for_streaming_command(
         thinking_quote: _,
         viewport,
         skills,
+        deferred_tab,
     } = wait_context;
     let started = std::time::Instant::now();
     let mut interval = tokio::time::interval(WAIT_LOOP_POLL_INTERVAL);
@@ -382,7 +491,7 @@ pub(crate) async fn wait_for_streaming_command(
                     output_state.push_text(&line);
                 }
                 while event::poll(std::time::Duration::ZERO)? {
-                    handle_input_event(
+                    let result = handle_input_event(
                         event::read()?,
                         input_state,
                         interrupt_state,
@@ -397,6 +506,20 @@ pub(crate) async fn wait_for_streaming_command(
                             skills,
                         },
                     );
+                    if let Some(
+                        outcome @ (InputResult::WorkspacePrevious
+                        | InputResult::WorkspaceNext
+                        | InputResult::WorkspaceNew
+                        | InputResult::WorkspaceClose),
+                    ) = result.outcome
+                    {
+                        *deferred_tab = Some(match outcome {
+                            InputResult::WorkspacePrevious => crate::workspace_tab::TabAction::Previous,
+                            InputResult::WorkspaceNext => crate::workspace_tab::TabAction::Next,
+                            InputResult::WorkspaceNew => crate::workspace_tab::TabAction::New,
+                            _ => crate::workspace_tab::TabAction::Close,
+                        });
+                    }
                     render.actual_width = viewport.actual_width;
                     render.actual_height = viewport.actual_height;
                     render.x_offset = viewport.x_offset;

--- a/src/bin/orangu/workspace_tab.rs
+++ b/src/bin/orangu/workspace_tab.rs
@@ -1,0 +1,465 @@
+// Copyright (C) 2026 The orangu community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! A single open workspace tab and its live runtime state.
+//!
+//! Each tab is its own session: its own conversation, scrollback, pending
+//! queue, command history and usage. The active tab's fields are used by the
+//! run loop exactly like the single-workspace locals were before tabs existed;
+//! switching tabs swaps which [`WorkspaceTab`] is active. The model and server
+//! are shared across tabs (per-workspace `/server`/`/model` come later).
+
+use crate::*;
+use orangu::workspaces::WorkspacePath;
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+/// Everything that belongs to one workspace tab. The run loop reads and mutates
+/// the active tab's fields; the [`WorkspaceManager`](orangu::workspaces::WorkspaceManager)
+/// owns the ordered list and tracks which tab is active.
+pub(crate) struct WorkspaceTab {
+    pub(crate) workspace: PathBuf,
+    pub(crate) tools: ToolExecutor,
+    pub(crate) skills: orangu::skills::SkillRegistry,
+    pub(crate) session: ChatSession,
+    pub(crate) output_state: OutputState,
+    pub(crate) pending_commands: VecDeque<String>,
+    pub(crate) usage_stats: UsageStats,
+    pub(crate) history: Vec<String>,
+    pub(crate) session_id: String,
+    pub(crate) session_dir: PathBuf,
+    pub(crate) session_hist_path: PathBuf,
+    pub(crate) session_messages_path: PathBuf,
+    pub(crate) session_metadata_path: PathBuf,
+    pub(crate) current_branch: Option<String>,
+    /// The last `/review` summary and `/auto_review` report (Markdown), kept so
+    /// `/comment <number> with [auto] review` can post them. Per tab, since a
+    /// review is of that tab's branch.
+    pub(crate) last_review_report: Option<String>,
+    pub(crate) last_auto_review_report: Option<String>,
+    pub(crate) last_review_was_auto: bool,
+    /// While set and in the future, the status bar shows "Resuming session …"
+    /// for a freshly auto-resumed tab.
+    pub(crate) startup_notice_until: Option<Instant>,
+    /// An LLM response running in a background tokio task because the user
+    /// switched tabs mid-stream. `session` is a placeholder while this is `Some`.
+    pub(crate) pending_response: Option<PendingResponse>,
+}
+
+impl WorkspacePath for WorkspaceTab {
+    fn workspace_path(&self) -> &Path {
+        &self.workspace
+    }
+}
+
+impl WorkspaceTab {
+    /// Open a workspace tab on `workspace`, resolving its session the same way a
+    /// standalone client start does: an explicit `resume` UUID is honoured,
+    /// otherwise the matching workspace+branch session is auto-resumed, else a
+    /// fresh session is created. `system_prompt` seeds the conversation (the
+    /// model is shared across tabs, so every tab starts from the same prompt).
+    ///
+    /// When `auto_resume` is false and no explicit `resume` is given, a brand
+    /// new session is always started rather than auto-resuming the matching one
+    /// — used by `Alt+Insert`, which opens a fresh tab the user then points
+    /// somewhere with `/workspace`.
+    pub(crate) fn open(
+        workspace: PathBuf,
+        resume: Option<&str>,
+        auto_resume: bool,
+        system_prompt: &str,
+    ) -> Result<Self> {
+        let workspace_created = if !workspace.exists() {
+            std::fs::create_dir_all(&workspace)
+                .with_context(|| format!("Failed to create workspace {}", workspace.display()))?;
+            true
+        } else {
+            false
+        };
+        let tools = ToolExecutor::new(&workspace);
+        let skills = orangu::skills::SkillRegistry::discover(&workspace);
+        let current_branch = workspace_branch_name(&workspace);
+
+        let (session_id, is_resumed) = match resume {
+            Some(id) => (id.to_string(), true),
+            None if auto_resume => {
+                let workspace_str = workspace.display().to_string();
+                match find_session_for_workspace_branch(
+                    &workspace_str,
+                    current_branch.as_deref().unwrap_or(""),
+                ) {
+                    Some(existing_id) => (existing_id, true),
+                    None => (Uuid::new_v4().to_string(), false),
+                }
+            }
+            None => (Uuid::new_v4().to_string(), false),
+        };
+        let session_dir = session_dir_path(&session_id)?;
+        std::fs::create_dir_all(&session_dir).with_context(|| {
+            format!(
+                "failed to create session directory {}",
+                session_dir.display()
+            )
+        })?;
+        let session_hist_path = session_dir.join("history");
+        let session_messages_path = session_dir.join("messages");
+        let session_metadata_path = session_dir.join("metadata");
+
+        if !is_resumed {
+            save_session_metadata(
+                &session_metadata_path,
+                &SessionMetadata {
+                    started_at: current_unix_timestamp(),
+                    last_updated_at: current_unix_timestamp(),
+                    workspace: workspace.display().to_string(),
+                    branch: current_branch.clone().unwrap_or_default(),
+                },
+            )?;
+        }
+
+        let enhanced_prompt = {
+            let index = skills.system_prompt_index();
+            if index.is_empty() {
+                system_prompt.to_string()
+            } else {
+                format!("{system_prompt}\n\n{index}")
+            }
+        };
+        let mut session = ChatSession::new(&enhanced_prompt);
+        if is_resumed {
+            session.restore(load_session_messages(&session_messages_path)?);
+        }
+
+        let usage_stats = UsageStats::new().with_session(&session_id);
+        let history = load_history(&session_hist_path)?;
+        let mut output_state = OutputState::default();
+        // The auto-resume notice only shows for a session restored implicitly on
+        // open, not for an explicit `--resume`/`/session <uuid>` target.
+        let startup_notice_until = if is_resumed && resume.is_none() {
+            Some(Instant::now() + Duration::from_secs(5))
+        } else {
+            None
+        };
+        if workspace_created {
+            output_state.push_text(&format!("Created workspace {}", workspace.display()));
+        }
+
+        Ok(Self {
+            workspace,
+            tools,
+            skills,
+            session,
+            output_state,
+            pending_commands: VecDeque::new(),
+            usage_stats,
+            history,
+            session_id,
+            session_dir,
+            session_hist_path,
+            session_messages_path,
+            session_metadata_path,
+            current_branch,
+            last_review_report: None,
+            last_auto_review_report: None,
+            last_review_was_auto: false,
+            startup_notice_until,
+            pending_response: None,
+        })
+    }
+
+    /// Persist this tab's conversation and bump its session's last-updated
+    /// timestamp. Called when leaving a tab (switch/close) and on quit, so every
+    /// tab a run touched is resumable afterwards.
+    pub(crate) fn save(&self) -> Result<()> {
+        // While a background streaming task owns the real session, `self.session`
+        // is a placeholder. Skip the message write so we don't overwrite the last
+        // good save with an empty placeholder conversation.
+        if self.pending_response.is_none() {
+            save_session_messages(&self.session_messages_path, self.session.messages())?;
+        }
+        update_session_metadata_timestamp(&self.session_metadata_path)?;
+        Ok(())
+    }
+
+    /// Finish this tab on exit: print its resume command, annotated with its
+    /// workspace and branch, or silently delete its session directory when the
+    /// session is ephemeral (no LLM interaction on `main`/`master` or outside a
+    /// Git repository). Run for every open tab so each one a run touched can be
+    /// resumed afterwards.
+    pub(crate) fn finish(&self) {
+        let branch = self.current_branch.as_deref().unwrap_or("");
+        if self.usage_stats.total_tokens == 0 && is_ephemeral_branch(branch) {
+            delete_session_dir(&self.session_dir);
+        } else {
+            eprintln!(
+                "orangu --resume {} ({}/{branch})",
+                self.session_id,
+                self.workspace.display()
+            );
+        }
+    }
+}
+
+/// The open workspace tabs other than the active one, plus where the active tab
+/// sits among them.
+///
+/// The active tab's live state lives in the run loop's locals (so the loop body
+/// is unchanged from the single-workspace days); this ring holds the rest. A
+/// switch *parks* the current active here and hands back the tab to make active,
+/// which the caller unpacks back into its locals. The same invariants as
+/// [`WorkspaceManager`](orangu::workspaces::WorkspaceManager) hold: there is
+/// always at least one tab, and closing renumbers the rest.
+pub(crate) struct WorkspaceRing {
+    others: Vec<WorkspaceTab>,
+    /// Index the active tab occupies in the full left-to-right order.
+    active_pos: usize,
+}
+
+impl WorkspaceRing {
+    /// A ring for a single active tab and no others.
+    pub(crate) fn new() -> Self {
+        Self {
+            others: Vec::new(),
+            active_pos: 0,
+        }
+    }
+
+    /// Total number of open tabs, including the active one.
+    pub(crate) fn total(&self) -> usize {
+        self.others.len() + 1
+    }
+
+    /// The active tab's 0-based position in the full left-to-right order.
+    pub(crate) fn active_pos(&self) -> usize {
+        self.active_pos
+    }
+
+    /// Park `active` and move focus by `delta` tabs (wrapping), returning the tab
+    /// that should become active. `delta` of `1` is the next tab on the right,
+    /// `-1` the previous on the left.
+    pub(crate) fn rotate(&mut self, active: WorkspaceTab, delta: isize) -> WorkspaceTab {
+        self.others.insert(self.active_pos, active);
+        let total = self.others.len() as isize;
+        self.active_pos = (self.active_pos as isize + delta).rem_euclid(total) as usize;
+        self.others.remove(self.active_pos)
+    }
+
+    /// Park `active` and open `new_tab` as the rightmost tab, making it active.
+    pub(crate) fn open(&mut self, active: WorkspaceTab, new_tab: WorkspaceTab) -> WorkspaceTab {
+        self.others.insert(self.active_pos, active);
+        self.active_pos = self.others.len();
+        new_tab
+    }
+
+    /// Switch to the tab at full-order `index`, parking `active`. Returns the tab
+    /// to make active, or gives `active` back unchanged when `index` is out of
+    /// range or already the active position.
+    pub(crate) fn switch_to(&mut self, active: WorkspaceTab, index: usize) -> WorkspaceTab {
+        if index == self.active_pos || index >= self.total() {
+            return active;
+        }
+        self.others.insert(self.active_pos, active);
+        self.active_pos = index;
+        self.others.remove(index)
+    }
+
+    /// Close the active tab (which the caller has already saved) and focus a
+    /// neighbour — its right neighbour, or the new last tab when it was the
+    /// rightmost. Returns `None` (dropping nothing) when it is the only tab open;
+    /// only `/quit` ends orangu.
+    pub(crate) fn close(&mut self, _active: WorkspaceTab) -> Option<WorkspaceTab> {
+        if self.others.is_empty() {
+            return None;
+        }
+        self.active_pos = self.active_pos.min(self.others.len() - 1);
+        Some(self.others.remove(self.active_pos))
+    }
+
+    /// The parked (non-active) tabs, for saving every tab a run touched on quit.
+    pub(crate) fn parked(&self) -> &[WorkspaceTab] {
+        &self.others
+    }
+
+    /// Append an already-open tab to the right without changing focus. Used at
+    /// startup by `orangu -a` to restore the previously open tabs behind the
+    /// active one.
+    pub(crate) fn park(&mut self, tab: WorkspaceTab) {
+        self.others.push(tab);
+    }
+
+    /// The full-order index of the tab open on `path`, given the active tab's
+    /// path. Used so `/workspace <path>` switches to an already-open directory
+    /// rather than opening a second tab for it.
+    pub(crate) fn position_of(&self, active: &Path, path: &Path) -> Option<usize> {
+        if active == path {
+            return Some(self.active_pos);
+        }
+        self.others
+            .iter()
+            .position(|t| t.workspace == path)
+            .map(|i| if i >= self.active_pos { i + 1 } else { i })
+    }
+}
+
+/// A change to which workspace tab is active, applied to the run loop's tab
+/// ring. Produced by the workspace key bindings and by the `/workspace` command.
+pub(crate) enum TabAction {
+    /// Focus the next tab on the right (`Alt+.`), wrapping.
+    Next,
+    /// Focus the previous tab on the left (`Alt+,`), wrapping.
+    Previous,
+    /// Focus the tab at the given full-order index (`/workspace <number>`).
+    SwitchTo(usize),
+    /// Open `path` as a new tab, or switch to it if already open
+    /// (`/workspace <path>`).
+    Open(PathBuf),
+    /// Start a fresh tab on the active workspace's directory (`Alt+Insert`); the
+    /// user re-points it with `/workspace` afterwards.
+    New,
+    /// Close the active tab (`Alt+Delete`); the last tab is never closed.
+    Close,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stub_tab(workspace: &str) -> WorkspaceTab {
+        WorkspaceTab {
+            workspace: PathBuf::from(workspace),
+            tools: ToolExecutor::new(std::path::Path::new(workspace)),
+            skills: orangu::skills::SkillRegistry::discover(std::path::Path::new(workspace)),
+            session: orangu::session::ChatSession::new(""),
+            output_state: OutputState::default(),
+            pending_commands: VecDeque::new(),
+            usage_stats: UsageStats::new(),
+            history: vec![],
+            session_id: workspace.to_string(),
+            session_dir: PathBuf::from(workspace),
+            session_hist_path: PathBuf::from(workspace),
+            session_messages_path: PathBuf::from(workspace),
+            session_metadata_path: PathBuf::from(workspace),
+            current_branch: None,
+            last_review_report: None,
+            last_auto_review_report: None,
+            last_review_was_auto: false,
+            startup_notice_until: None,
+            pending_response: None,
+        }
+    }
+
+    fn workspaces(ring: &WorkspaceRing, active: &WorkspaceTab) -> Vec<String> {
+        let mut result = ring
+            .parked()
+            .iter()
+            .map(|t| t.session_id.clone())
+            .collect::<Vec<_>>();
+        result.insert(ring.active_pos(), active.session_id.clone());
+        result
+    }
+
+    #[test]
+    fn rotate_next_wraps_at_end() {
+        let mut ring = WorkspaceRing::new();
+        let a = stub_tab("/a");
+        let b = stub_tab("/b");
+        let c = stub_tab("/c");
+        // Build ring: active=/a, parked=[/b, /c] at positions 1,2
+        let active = ring.open(a, b); // active=/b, parked=[/a]
+        let active = ring.open(active, c); // active=/c, parked=[/a,/b]
+        assert_eq!(ring.active_pos(), 2);
+
+        let active = ring.rotate(active, 1); // wraps to 0 → /a
+        assert_eq!(active.session_id, "/a");
+        assert_eq!(ring.active_pos(), 0);
+    }
+
+    #[test]
+    fn rotate_previous_wraps_at_start() {
+        let mut ring = WorkspaceRing::new();
+        let a = stub_tab("/a");
+        let b = stub_tab("/b");
+        let c = stub_tab("/c");
+        let active = ring.open(a, b);
+        let active = ring.open(active, c);
+        // active=/c at pos 2; rotate to pos 0 first
+        let active = ring.rotate(active, 1); // /a at pos 0
+        assert_eq!(active.session_id, "/a");
+
+        let active = ring.rotate(active, -1); // wraps 0 → 2 → /c
+        assert_eq!(active.session_id, "/c");
+        assert_eq!(ring.active_pos(), 2);
+    }
+
+    #[test]
+    fn switch_to_out_of_range_returns_active_unchanged() {
+        let mut ring = WorkspaceRing::new();
+        let a = stub_tab("/a");
+        let b = stub_tab("/b");
+        let active = ring.open(a, b);
+        assert_eq!(ring.active_pos(), 1);
+
+        let active = ring.switch_to(active, 5); // out of range
+        assert_eq!(active.session_id, "/b");
+        assert_eq!(ring.active_pos(), 1);
+    }
+
+    #[test]
+    fn close_last_tab_returns_none() {
+        let mut ring = WorkspaceRing::new();
+        let a = stub_tab("/a");
+        assert!(ring.close(a).is_none());
+    }
+
+    #[test]
+    fn close_renumbers_and_focuses_right_neighbour() {
+        let mut ring = WorkspaceRing::new();
+        let a = stub_tab("/a");
+        let b = stub_tab("/b");
+        let c = stub_tab("/c");
+        let active = ring.open(a, b);
+        let active = ring.open(active, c);
+        // layout: [/a, /b, /c], active=/c at pos 2
+        let active = ring.switch_to(active, 1); // switch to /b
+        assert_eq!(active.session_id, "/b");
+
+        let new_active = ring.close(active).expect("two tabs remain");
+        // /b was at pos 1; right neighbour is /c (now at pos 1)
+        assert_eq!(new_active.session_id, "/c");
+        assert_eq!(ring.active_pos(), 1);
+        assert_eq!(ring.total(), 2);
+    }
+
+    #[test]
+    fn position_of_finds_active_and_parked() {
+        let mut ring = WorkspaceRing::new();
+        let a = stub_tab("/a");
+        let b = stub_tab("/b");
+        let active = ring.open(a, b); // active=/b at pos 1, parked=[/a]
+
+        assert_eq!(
+            ring.position_of(&active.workspace, std::path::Path::new("/b")),
+            Some(1)
+        );
+        assert_eq!(
+            ring.position_of(&active.workspace, std::path::Path::new("/a")),
+            Some(0)
+        );
+        assert_eq!(
+            ring.position_of(&active.workspace, std::path::Path::new("/z")),
+            None
+        );
+    }
+}

--- a/src/tui/screen.rs
+++ b/src/tui/screen.rs
@@ -14,8 +14,31 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
+use crate::workspaces::WorkspacePlacement;
 use std::time::Duration;
 use terminal_size::{Height, Width, terminal_size};
+
+/// The workspace tab bar to draw: how many tabs are open, which is active
+/// (0-based, left to right) and where the bar sits relative to the screen.
+#[derive(Clone, Copy)]
+pub struct WorkspaceTabsView {
+    pub count: usize,
+    pub active: usize,
+    pub placement: WorkspacePlacement,
+}
+
+/// Status of a single open workspace tab, shown as a colored dot in the tab
+/// bar when the `feedback` configuration key is on.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum TabStatus {
+    /// The workspace directory and branch are valid (green ●).
+    Valid,
+    /// The live branch no longer matches the one the tab was opened on —
+    /// probably deleted or merged (red ●).
+    BranchGone,
+    /// The active tab is currently streaming a response (blinking white ●).
+    Working,
+}
 
 pub(crate) const USER_INPUT_BACKGROUND: &str = "\x1b[48;2;44;44;44m";
 const GHOST_TEXT: &str = "\x1b[38;2;120;120;120m";
@@ -31,6 +54,10 @@ pub struct ScreenRenderArgs<'a> {
     pub prompt_branch: Option<&'a str>,
     pub status: HeaderStatus,
     pub banner: Banner,
+    pub tab_bar: Option<WorkspaceTabsView>,
+    /// Per-tab status dots for the tab bar, in left-to-right order. Empty when
+    /// `feedback` is off; when non-empty has exactly `tab_bar.count` entries.
+    pub tab_statuses: &'a [TabStatus],
     pub transcript: &'a [TranscriptLine],
     pub scroll_offset: usize,
     pub left_status: Option<StatusFragment>,
@@ -60,7 +87,94 @@ pub struct PromptFrameArgs<'a> {
     pub actual_width: usize,
 }
 
+fn tab_dot(status: TabStatus) -> &'static str {
+    match status {
+        TabStatus::Valid => "\x1b[38;2;80;200;120m●\x1b[0m",
+        TabStatus::BranchGone => "\x1b[38;2;220;80;80m●\x1b[0m",
+        TabStatus::Working => "\x1b[5;38;2;230;230;230m●\x1b[0m",
+    }
+}
+
+/// The horizontal workspace tab bar (`1 │ 2 │ 3`, active tab bold) for top and
+/// bottom placement, clipped to `width`. When `statuses` is non-empty a
+/// colored dot precedes each tab number.
+fn horizontal_tab_bar(view: WorkspaceTabsView, width: usize, statuses: &[TabStatus]) -> String {
+    let cells: Vec<String> = (0..view.count)
+        .map(|index| {
+            let number = index + 1;
+            let dot = statuses.get(index).copied().map(tab_dot).unwrap_or("");
+            if index == view.active {
+                format!("{dot}\x1b[1m{number}\x1b[0m")
+            } else {
+                format!("{dot}{GHOST_TEXT}{number}{ANSI_RESET}")
+            }
+        })
+        .collect();
+    clip_line(&cells.join(" │ "), 0, width)
+}
+
+/// Width of the vertical tab gutter: the widest tab number plus ` │ `, and one
+/// extra column when status dots are shown.
+fn tab_gutter_width(view: WorkspaceTabsView, has_dots: bool) -> usize {
+    view.count.to_string().len() + 3 + usize::from(has_dots)
+}
+
+/// The gutter cell for screen `row` on a left/right placement: the tab number
+/// (bold when active) on the first `count` rows, blank after, always carrying
+/// the separator bar — `N │ ` on the left, ` │ N` on the right. When
+/// `statuses` is non-empty, a colored dot precedes each tab number.
+fn tab_gutter_cell(
+    view: WorkspaceTabsView,
+    row: usize,
+    left: bool,
+    statuses: &[TabStatus],
+) -> String {
+    let digits = view.count.to_string().len();
+    let dot = if statuses.is_empty() {
+        String::new()
+    } else if let Some(&status) = statuses.get(row) {
+        tab_dot(status).to_string()
+    } else {
+        " ".to_string()
+    };
+    let label = if row < view.count {
+        let number = row + 1;
+        if row == view.active {
+            format!("\x1b[1m{number:>digits$}\x1b[0m")
+        } else {
+            format!("{GHOST_TEXT}{number:>digits$}{ANSI_RESET}")
+        }
+    } else {
+        " ".repeat(digits)
+    };
+    if left {
+        format!("{dot}{label} │ ")
+    } else {
+        format!(" │ {dot}{label}")
+    }
+}
+
 pub fn render_screen(args: ScreenRenderArgs<'_>) -> String {
+    let width = args.virtual_width.max(1);
+    let actual_width = args.actual_width.max(1);
+    let actual_height = args.actual_height.max(1);
+
+    // Where the workspace tab bar sits. Top/bottom take a row of the screen;
+    // left/right take a gutter column from the banner and output region.
+    let placement = args.tab_bar.map(|view| view.placement);
+    let top_row = usize::from(placement == Some(WorkspacePlacement::Top));
+    let bottom_row = usize::from(placement == Some(WorkspacePlacement::Bottom));
+    let left = placement == Some(WorkspacePlacement::Left);
+    let right = placement == Some(WorkspacePlacement::Right);
+    let has_dots = !args.tab_statuses.is_empty();
+    let gutter = match args.tab_bar {
+        Some(view) if left || right => tab_gutter_width(view, has_dots),
+        _ => 0,
+    };
+    let inner_width = actual_width.saturating_sub(gutter).max(1);
+    // The prompt frame keeps the full width; a bottom bar shrinks its height.
+    let frame_height = actual_height.saturating_sub(bottom_row).max(1);
+
     let header = render_header(
         args.version,
         args.current_model,
@@ -68,32 +182,31 @@ pub fn render_screen(args: ScreenRenderArgs<'_>) -> String {
         args.workspace,
         args.status,
         args.banner,
-        args.actual_width,
+        inner_width,
     );
     let header_line_count = header.lines().count();
-    let width = args.virtual_width.max(1);
-    let actual_width = args.actual_width.max(1);
-    let actual_height = args.actual_height.max(1);
     let prompt_prefix = prompt_prefix(args.prompt_branch);
     let input_lines = wrapped_input_lines(args.input, actual_width, &prompt_prefix);
     let prompt_frame_height = input_lines.len() + 3;
 
     // Priority: prompt frame first, then banner, then output.
-    let rows_above_prompt = actual_height.saturating_sub(prompt_frame_height);
+    let rows_above_prompt = frame_height.saturating_sub(prompt_frame_height);
     // Banner = header lines + 1 blank separator line; truncate to what fits.
     let full_banner_height = header_line_count + 1;
     let banner_rows = full_banner_height.min(rows_above_prompt);
-    let available_output_rows = available_output_rows(rows_above_prompt, banner_rows);
+    // A top bar takes one row from the output area.
+    let available_output_rows =
+        available_output_rows(rows_above_prompt, banner_rows).saturating_sub(top_row);
 
     let mut output_lines = args
         .transcript
         .iter()
         .map(|line| {
             let (rendered, offset) = match line {
-                TranscriptLine::UserInput(_) => (render_transcript_line(line, actual_width), 0),
+                TranscriptLine::UserInput(_) => (render_transcript_line(line, inner_width), 0),
                 _ => (render_transcript_line(line, width), args.x_offset),
             };
-            clip_line(&rendered, offset, actual_width)
+            clip_line(&rendered, offset, inner_width)
         })
         .collect::<Vec<_>>();
     if let Some(pending_line) = args.pending_line {
@@ -103,7 +216,7 @@ pub fn render_screen(args: ScreenRenderArgs<'_>) -> String {
             output_lines.extend(
                 pending_line
                     .lines()
-                    .map(|l| clip_line(l, args.x_offset, actual_width)),
+                    .map(|l| clip_line(l, args.x_offset, inner_width)),
             );
         }
     }
@@ -113,28 +226,63 @@ pub fn render_screen(args: ScreenRenderArgs<'_>) -> String {
     let visible_start = visible_end.saturating_sub(available_output_rows);
     let visible_lines = &output_lines[visible_start..visible_end];
 
-    let mut screen = String::new();
-
-    // Banner — show as many header lines as fit; add blank separator only when full banner fits.
+    // The banner and output region, as rows at `inner_width`.
+    let mut upper: Vec<String> = Vec::new();
     if banner_rows > 0 {
         let shown_header_lines = banner_rows.min(header_line_count);
-        let banner_content = header
-            .split("\r\n")
-            .take(shown_header_lines)
-            .map(|l| clip_line(l, 0, actual_width))
-            .collect::<Vec<_>>()
-            .join("\r\n");
-        screen.push_str(&banner_content);
-        screen.push_str("\r\n");
+        for line in header.split("\r\n").take(shown_header_lines) {
+            upper.push(clip_line(line, 0, inner_width));
+        }
         if banner_rows > header_line_count {
-            screen.push_str("\r\n"); // blank separator line
+            upper.push(String::new());
         }
     }
+    upper.extend(visible_lines.iter().cloned());
 
-    if !visible_lines.is_empty() {
-        screen.push_str(&visible_lines.join("\r\n"));
+    let mut screen = String::new();
+
+    // Pre-compute the horizontal bar string once; used by at most one of the
+    // top/bottom branches (they are mutually exclusive), but computing upfront
+    // avoids repeating the Vec+join allocation if this function is ever called
+    // in a context where placement could be re-evaluated.
+    let h_tab_bar: Option<String> = if top_row == 1 || bottom_row == 1 {
+        args.tab_bar
+            .map(|view| horizontal_tab_bar(view, actual_width, args.tab_statuses))
+    } else {
+        None
+    };
+
+    // Top tab bar.
+    if top_row == 1
+        && let Some(ref bar) = h_tab_bar
+    {
+        screen.push_str(bar);
         screen.push_str("\r\n");
     }
+
+    // Banner and output, with a left/right gutter when placed vertically.
+    if let (true, Some(view)) = (left || right, args.tab_bar) {
+        for row in 0..rows_above_prompt {
+            let content = upper.get(row).cloned().unwrap_or_default();
+            let cell = tab_gutter_cell(view, row, left, args.tab_statuses);
+            if left {
+                screen.push_str(&cell);
+                screen.push_str(&content);
+            } else {
+                let pad = inner_width.saturating_sub(visible_line_width(&content));
+                screen.push_str(&content);
+                for _ in 0..pad {
+                    screen.push(' ');
+                }
+                screen.push_str(&cell);
+            }
+            screen.push_str("\r\n");
+        }
+    } else if !upper.is_empty() {
+        screen.push_str(&upper.join("\r\n"));
+        screen.push_str("\r\n");
+    }
+
     screen.push_str(&render_prompt_frame(PromptFrameArgs {
         header_height: banner_rows,
         current_model: args.current_model,
@@ -144,9 +292,29 @@ pub fn render_screen(args: ScreenRenderArgs<'_>) -> String {
         input: args.input,
         cursor: args.cursor,
         ghost: args.ghost,
-        height: actual_height,
+        height: frame_height,
         actual_width,
     }));
+
+    // Bottom tab bar on the last terminal row.
+    if bottom_row == 1
+        && let Some(ref bar) = h_tab_bar
+    {
+        screen.push_str(&format!("\x1b[{actual_height};1H{bar}"));
+        // Writing the bar moved the cursor to the last row; put it back in the
+        // input area so keystrokes land in the right place.
+        let input_height = input_lines.len();
+        let pf_height = frame_height.max(banner_rows + input_height + 3);
+        let pf_top_row = (pf_height.saturating_sub(input_height + 2)).max(banner_rows + 1);
+        let pf_input_start = pf_top_row + 1;
+        let pf_prompt_width = prompt_prefix.chars().count();
+        let (cr_offset, cc_offset) =
+            cursor_position(args.input, args.cursor, actual_width, &prompt_prefix);
+        let cr = pf_input_start + cr_offset;
+        let cc = (1 + pf_prompt_width + cc_offset).max(1);
+        screen.push_str(&format!("\x1b[{cr};{cc}H"));
+    }
+
     screen
 }
 

--- a/src/workspaces.rs
+++ b/src/workspaces.rs
@@ -69,12 +69,22 @@ impl FromStr for WorkspacePlacement {
     }
 }
 
+/// A workspace tab identified by its directory.
+///
+/// [`WorkspaceManager`] is generic over the tab payload so the binary can hang
+/// a tab's live runtime state (its session, conversation, pending queue, …) off
+/// its own richer type while reusing the bookkeeping here; that payload only
+/// has to report its directory through [`WorkspacePath`]. `Workspace` is the
+/// minimal payload — just the directory — and the manager's default.
+pub trait WorkspacePath {
+    /// The directory this workspace is open on.
+    fn workspace_path(&self) -> &Path;
+}
+
 /// A single workspace tab.
 ///
-/// Identified by its directory. The per-tab runtime state (its session,
-/// conversation, pending queue and optional server/model override) will hang
-/// off this type as the feature is built out; for now a workspace is just the
-/// directory it is open on.
+/// Identified by its directory — the minimal [`WorkspacePath`] payload, used
+/// where only the directory matters (and as the manager's default tab type).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Workspace {
     path: PathBuf,
@@ -96,19 +106,25 @@ impl Workspace {
     }
 }
 
+impl WorkspacePath for Workspace {
+    fn workspace_path(&self) -> &Path {
+        &self.path
+    }
+}
+
 /// The ordered set of open workspace tabs and which one is active.
 ///
 /// Invariant: `workspaces` is never empty and `active` is always a valid index
 /// into it. Every method preserves both.
 #[derive(Debug, Clone)]
-pub struct WorkspaceManager {
-    workspaces: Vec<Workspace>,
+pub struct WorkspaceManager<W = Workspace> {
+    workspaces: Vec<W>,
     active: usize,
 }
 
-impl WorkspaceManager {
+impl<W> WorkspaceManager<W> {
     /// Start with a single workspace, which becomes the active tab (tab 1).
-    pub fn new(initial: Workspace) -> Self {
+    pub fn new(initial: W) -> Self {
         Self {
             workspaces: vec![initial],
             active: 0,
@@ -133,28 +149,23 @@ impl WorkspaceManager {
     }
 
     /// The active workspace.
-    pub fn active(&self) -> &Workspace {
+    pub fn active(&self) -> &W {
         &self.workspaces[self.active]
     }
 
     /// The active workspace, mutably.
-    pub fn active_mut(&mut self) -> &mut Workspace {
+    pub fn active_mut(&mut self) -> &mut W {
         &mut self.workspaces[self.active]
     }
 
     /// All open workspaces, in tab order.
-    pub fn workspaces(&self) -> &[Workspace] {
+    pub fn workspaces(&self) -> &[W] {
         &self.workspaces
     }
 
     /// The workspace at `index`, if any.
-    pub fn get(&self, index: usize) -> Option<&Workspace> {
+    pub fn get(&self, index: usize) -> Option<&W> {
         self.workspaces.get(index)
-    }
-
-    /// The index of the tab open on `path`, if one is.
-    pub fn position_of(&self, path: &Path) -> Option<usize> {
-        self.workspaces.iter().position(|w| w.path() == path)
     }
 
     /// Open `workspace` as a new tab to the right of the others and make it
@@ -164,23 +175,10 @@ impl WorkspaceManager {
     /// tabs. Use [`open_or_switch`](Self::open_or_switch) for the
     /// `/workspace <path>` behaviour, where an already-open directory is
     /// switched to rather than opened again.
-    pub fn open(&mut self, workspace: Workspace) -> usize {
+    pub fn open(&mut self, workspace: W) -> usize {
         self.workspaces.push(workspace);
         self.active = self.workspaces.len() - 1;
         self.active
-    }
-
-    /// Switch to the tab open on `workspace`'s path if there already is one,
-    /// otherwise open a new tab for it. Either way the matching tab ends up
-    /// active. Returns its index.
-    pub fn open_or_switch(&mut self, workspace: Workspace) -> usize {
-        match self.position_of(workspace.path()) {
-            Some(index) => {
-                self.active = index;
-                index
-            }
-            None => self.open(workspace),
-        }
     }
 
     /// Make the tab at `index` active. Returns `false` (and changes nothing) if
@@ -235,9 +233,31 @@ impl WorkspaceManager {
     }
 }
 
+impl<W: WorkspacePath> WorkspaceManager<W> {
+    /// The index of the tab open on `path`, if one is.
+    pub fn position_of(&self, path: &Path) -> Option<usize> {
+        self.workspaces
+            .iter()
+            .position(|w| w.workspace_path() == path)
+    }
+
+    /// Switch to the tab open on `workspace`'s path if there already is one,
+    /// otherwise open a new tab for it. Either way the matching tab ends up
+    /// active. Returns its index.
+    pub fn open_or_switch(&mut self, workspace: W) -> usize {
+        match self.position_of(workspace.workspace_path()) {
+            Some(index) => {
+                self.active = index;
+                index
+            }
+            None => self.open(workspace),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{Workspace, WorkspaceManager, WorkspacePlacement};
+    use super::{Workspace, WorkspaceManager, WorkspacePath, WorkspacePlacement};
     use std::path::{Path, PathBuf};
 
     fn ws(path: &str) -> Workspace {
@@ -426,5 +446,56 @@ mod tests {
         assert!(manager.close(2)); // remove /c
         assert_eq!(manager.active().path(), Path::new("/a"));
         assert_eq!(manager.active_index(), 0);
+    }
+
+    #[test]
+    fn workspace_path_trait_returns_same_path_as_path() {
+        let w = ws("/foo/bar");
+        assert_eq!(w.workspace_path(), w.path());
+        assert_eq!(w.workspace_path(), Path::new("/foo/bar"));
+    }
+
+    #[test]
+    fn active_mut_allows_in_place_mutation() {
+        let mut manager = WorkspaceManager::new(ws("/original"));
+        *manager.active_mut() = ws("/replaced");
+        assert_eq!(manager.active().path(), Path::new("/replaced"));
+        assert_eq!(manager.len(), 1);
+    }
+
+    #[test]
+    fn get_returns_tab_at_index_or_none() {
+        let manager = manager(&["/a", "/b", "/c"]);
+        assert_eq!(manager.get(0).map(Workspace::path), Some(Path::new("/a")));
+        assert_eq!(manager.get(1).map(Workspace::path), Some(Path::new("/b")));
+        assert_eq!(manager.get(2).map(Workspace::path), Some(Path::new("/c")));
+        assert!(manager.get(3).is_none());
+    }
+
+    struct Tagged {
+        path: PathBuf,
+        label: &'static str,
+    }
+
+    impl WorkspacePath for Tagged {
+        fn workspace_path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    #[test]
+    fn workspace_manager_works_with_custom_workspace_path_impl() {
+        let mut manager = WorkspaceManager::new(Tagged {
+            path: PathBuf::from("/x"),
+            label: "x",
+        });
+        let idx = manager.open(Tagged {
+            path: PathBuf::from("/y"),
+            label: "y",
+        });
+        assert_eq!(idx, 1);
+        assert_eq!(manager.active().label, "y");
+        assert_eq!(manager.position_of(Path::new("/x")), Some(0));
+        assert_eq!(manager.position_of(Path::new("/y")), Some(1));
     }
 }


### PR DESCRIPTION
Make workspace tabs live in one orangu instead of re-execing per switch. Several workspaces stay open at once, each its own session, conversation, scrollback, pending queue and history.

The run loop keeps the active tab's state in its existing locals; a WorkspaceRing parks the other tabs and swaps the active one in and out, so the loop body is unchanged. Switching is deferred to the top of the next iteration so it never races the render context's borrows.

Keys at the prompt: Alt+, / Alt+. move to the previous/next tab (wrapping), Alt+Insert starts a new workspace (pre-filling /workspace), Alt+Delete closes the active tab (the last tab is never closed; only /quit exits). /workspace now switches and opens live tabs instead of re-execing: a number selects a tab, a directory opens one (or switches if already open).

A tab bar under the banner shows the open tabs with the active one bold, once more than one is open. On exit every open tab is saved and prints its own resume line annotated with its workspace and branch.

WorkspaceManager is made generic over the tab payload (WorkspacePath) so the binary's rich tab type reuses the tested bookkeeping.

The status-bar tab placement (workspaces=bottom|left|right) and per-tab server/model are follow-ups.