### PR TITLE
[#30] Fix tab dot: parked tabs always red due to branch-mismatch check

### DIFF
--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -1497,18 +1497,21 @@ async fn run() -> Result<()> {
 }
 
 /// Determine the feedback-dot status of a parked (non-active) workspace tab.
-/// Checks whether the tab's recorded branch is still the workspace's live
-/// branch; a mismatch signals that the branch was deleted or merged.
+///
+/// The dot is green (Valid) when the workspace directory still exists and no
+/// background LLM task is running, and red (BranchGone) only when the
+/// directory itself has disappeared (deleted project, unmounted drive, …).
+///
+/// A branch-mismatch check was tried here but produced false positives: two
+/// tabs that share the same workspace path read the same `.git/HEAD`, so any
+/// branch change in one tab incorrectly turns the other tab red. Branch state
+/// is already visible in each tab's status bar, so the dot does not need to
+/// duplicate it.
 fn parked_tab_status(tab: &WorkspaceTab) -> TabStatus {
     if tab.pending_response.is_some() {
         return TabStatus::Working;
     }
     if !tab.workspace.is_dir() {
-        return TabStatus::BranchGone;
-    }
-    if let Some(recorded) = &tab.current_branch
-        && workspace_branch_name(&tab.workspace).as_deref() != Some(recorded.as_str())
-    {
         return TabStatus::BranchGone;
     }
     TabStatus::Valid


### PR DESCRIPTION
parked_tab_status was comparing the parked tab's recorded branch against workspace_branch_name() at render time. When two tabs share the same workspace directory (the common case with Alt+Insert) they read the same .git/HEAD, so any branch change in the active tab immediately turned the parked tab's dot red, even though the parked tab was perfectly healthy. This produced the "alternating by view" pattern Jesper observed: the active tab is always hardcoded Valid (green) while the parked tab ran the branch check and returned BranchGone (red).

The branch a parked tab is on is already shown in the status bar of that tab; the dot does not need to duplicate it. Remove the branch comparison; the dot now only turns red when the workspace directory itself is gone (deleted project, unmounted drive).