### PR TITLE
[#30] Real-time parked-tab dot: blinking white -> green on stream finish

### DIFF
--- a/src/bin/orangu/input.rs
+++ b/src/bin/orangu/input.rs
@@ -268,6 +268,7 @@ pub struct WaitContext<'a> {
     /// wait (streaming, blocking command), the action is stored here instead of
     /// dropped, so `main` can apply it as soon as the wait returns.
     pub deferred_tab: &'a mut Option<crate::workspace_tab::TabAction>,
+    pub parked_tabs: &'a [crate::workspace_tab::WorkspaceTab],
 }
 
 #[derive(Default)]

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -473,8 +473,8 @@ async fn run() -> Result<()> {
             placement: config.workspaces,
         });
         // Per-tab colored dots: only computed when feedback is on and multiple
-        // tabs are open. Indexed left-to-right; parked tabs check whether their
-        // recorded branch is still the workspace's live branch.
+        // tabs are open. The wait loop recomputes these from live handle state
+        // on every render tick so parked-tab dots update without a tab switch.
         let tab_statuses: Vec<TabStatus> = if config.feedback && ring.total() > 1 {
             let active_pos = ring.active_pos();
             (0..ring.total())
@@ -483,7 +483,7 @@ async fn run() -> Result<()> {
                         TabStatus::Valid
                     } else {
                         let others_idx = if pos < active_pos { pos } else { pos - 1 };
-                        parked_tab_status(&ring.parked()[others_idx])
+                        ring.parked()[others_idx].dot_status()
                     }
                 })
                 .collect()
@@ -589,6 +589,7 @@ async fn run() -> Result<()> {
                     viewport: &mut viewport,
                     skills: &skills,
                     deferred_tab: &mut deferred_tab_during_wait,
+                    parked_tabs: ring.parked(),
                 },
             )
             .await;
@@ -976,6 +977,7 @@ async fn run() -> Result<()> {
                         viewport: &mut viewport,
                         skills: &skills,
                         deferred_tab: &mut deferred_tab_during_wait,
+                        parked_tabs: ring.parked(),
                     },
                     handle,
                 )
@@ -1036,6 +1038,7 @@ async fn run() -> Result<()> {
                         viewport: &mut viewport,
                         skills: &skills,
                         deferred_tab: &mut deferred_tab_during_wait,
+                        parked_tabs: ring.parked(),
                     },
                     handle,
                     &mut rx,
@@ -1394,6 +1397,7 @@ async fn run() -> Result<()> {
                 viewport: &mut viewport,
                 skills: &skills,
                 deferred_tab: &mut deferred_tab_during_wait,
+                parked_tabs: ring.parked(),
             },
         )
         .await
@@ -1498,27 +1502,6 @@ async fn run() -> Result<()> {
         tab.finish();
     }
     Ok(())
-}
-
-/// Determine the feedback-dot status of a parked (non-active) workspace tab.
-///
-/// The dot is green (Valid) when the workspace directory still exists and no
-/// background LLM task is running, and red (BranchGone) only when the
-/// directory itself has disappeared (deleted project, unmounted drive, …).
-///
-/// A branch-mismatch check was tried here but produced false positives: two
-/// tabs that share the same workspace path read the same `.git/HEAD`, so any
-/// branch change in one tab incorrectly turns the other tab red. Branch state
-/// is already visible in each tab's status bar, so the dot does not need to
-/// duplicate it.
-fn parked_tab_status(tab: &WorkspaceTab) -> TabStatus {
-    if tab.pending_response.is_some() {
-        return TabStatus::Working;
-    }
-    if !tab.workspace.is_dir() {
-        return TabStatus::BranchGone;
-    }
-    TabStatus::Valid
 }
 
 fn llm_prompt_block_reason(

--- a/src/bin/orangu/wait.rs
+++ b/src/bin/orangu/wait.rs
@@ -132,6 +132,7 @@ async fn drive_handle(
         viewport,
         skills,
         deferred_tab,
+        parked_tabs,
     } = wait_context;
 
     let mut handle = handle;
@@ -149,19 +150,25 @@ async fn drive_handle(
     ));
     let quote_line = thinking_quote.map(|q| format!("\x1b[2m{q}\x1b[0m"));
 
-    print_screen(
-        render,
-        ScreenState {
-            transcript: output_state.lines(),
-            scroll_offset: output_state.scroll_offset(),
-            left_status: initial_status,
-            pending_count: pending_commands.len(),
-            pending_line: quote_line.as_deref(),
-            input: input_state.as_str(),
-            cursor: input_state.cursor(),
-            ghost_index: input_state.ghost_index,
-        },
-    );
+    {
+        let live = live_tab_statuses(parked_tabs, render.tab_bar);
+        print_screen(
+            RenderContext {
+                tab_statuses: &live,
+                ..render
+            },
+            ScreenState {
+                transcript: output_state.lines(),
+                scroll_offset: output_state.scroll_offset(),
+                left_status: initial_status,
+                pending_count: pending_commands.len(),
+                pending_line: quote_line.as_deref(),
+                input: input_state.as_str(),
+                cursor: input_state.cursor(),
+                ghost_index: input_state.ghost_index,
+            },
+        );
+    }
     std::io::stdout().flush()?;
 
     loop {
@@ -186,8 +193,9 @@ async fn drive_handle(
                             final_pending_line(&final_state.output, &response)
                                 .map(|line| render_markdown_for_console(&line))
                         {
+                            let live = live_tab_statuses(parked_tabs, render.tab_bar);
                             print_screen(
-                                render,
+                                RenderContext { tab_statuses: &live, ..render },
                                 ScreenState {
                                     transcript: output_state.lines(),
                                     scroll_offset: output_state.scroll_offset(),
@@ -340,8 +348,9 @@ async fn drive_handle(
                     } else {
                         render_markdown_for_console(&last_rendered_output)
                     };
+                    let live = live_tab_statuses(parked_tabs, render.tab_bar);
                     print_screen(
-                        render,
+                        RenderContext { tab_statuses: &live, ..render },
                         ScreenState {
                             transcript: output_state.lines(),
                             scroll_offset: output_state.scroll_offset(),
@@ -378,6 +387,7 @@ pub(crate) async fn wait_for_local_command(
         viewport,
         skills,
         deferred_tab,
+        parked_tabs,
     } = wait_context;
     let started = std::time::Instant::now();
     let mut interval = tokio::time::interval(WAIT_LOOP_POLL_INTERVAL);
@@ -428,8 +438,9 @@ pub(crate) async fn wait_for_local_command(
                     render.x_offset = viewport.x_offset;
                 }
                 let left_status = Some(render_tool_running_status(frame, elapsed));
+                let live = live_tab_statuses(parked_tabs, render.tab_bar);
                 print_screen(
-                    render,
+                    RenderContext { tab_statuses: &live, ..render },
                     ScreenState {
                         transcript: output_state.lines(),
                         scroll_offset: output_state.scroll_offset(),
@@ -468,6 +479,7 @@ pub(crate) async fn wait_for_streaming_command(
         viewport,
         skills,
         deferred_tab,
+        parked_tabs,
     } = wait_context;
     let started = std::time::Instant::now();
     let mut interval = tokio::time::interval(WAIT_LOOP_POLL_INTERVAL);
@@ -525,8 +537,9 @@ pub(crate) async fn wait_for_streaming_command(
                     render.x_offset = viewport.x_offset;
                 }
                 let left_status = Some(render_tool_running_status(frame, elapsed));
+                let live = live_tab_statuses(parked_tabs, render.tab_bar);
                 print_screen(
-                    render,
+                    RenderContext { tab_statuses: &live, ..render },
                     ScreenState {
                         transcript: output_state.lines(),
                         scroll_offset: output_state.scroll_offset(),
@@ -542,6 +555,28 @@ pub(crate) async fn wait_for_streaming_command(
             }
         }
     }
+}
+
+fn live_tab_statuses(
+    parked_tabs: &[WorkspaceTab],
+    tab_bar: Option<WorkspaceTabsView>,
+) -> Vec<TabStatus> {
+    let Some(bar) = tab_bar else {
+        return vec![];
+    };
+    if parked_tabs.is_empty() {
+        return vec![];
+    }
+    (0..bar.count)
+        .map(|pos| {
+            if pos == bar.active {
+                TabStatus::Working
+            } else {
+                let idx = if pos < bar.active { pos } else { pos - 1 };
+                parked_tabs[idx].dot_status()
+            }
+        })
+        .collect()
 }
 
 pub(crate) fn render_left_status(

--- a/src/bin/orangu/workspace_tab.rs
+++ b/src/bin/orangu/workspace_tab.rs
@@ -210,6 +210,20 @@ impl WorkspaceTab {
             );
         }
     }
+
+    pub(crate) fn dot_status(&self) -> TabStatus {
+        if let Some(pr) = &self.pending_response {
+            return if pr.handle.is_finished() {
+                TabStatus::Valid
+            } else {
+                TabStatus::Working
+            };
+        }
+        if !self.workspace.is_dir() {
+            return TabStatus::BranchGone;
+        }
+        TabStatus::Valid
+    }
 }
 
 /// The open workspace tabs other than the active one, plus where the active tab


### PR DESCRIPTION
Parked tabs now transition from blinking white to green automatically when their background LLM task finishes, without requiring a tab switch.

Previously the dot color was computed once per main-loop iteration and frozen for the entire wait. Now each render tick inside drive_handle, wait_for_local_command and wait_for_streaming_command calls dot_status() on each parked tab's live JoinHandle via is_finished(), so the dot updates in real time as soon as the task completes.

- WorkspaceTab::dot_status(): canonical per-tab dot logic, checks handle.is_finished() to distinguish Working from Valid
- WaitContext::parked_tabs: slice passed through all three wait fns
- live_tab_statuses(): recomputes fresh Vec<TabStatus> from parked tabs on every render tick inside any wait
- parked_tab_status() removed; callers use dot_status() directly