### PR TITLE
[#30] /workspace <dir> switches tab in-place; fix workspaces file order

### DIFF
--- a/src/bin/orangu/commands/mod.rs
+++ b/src/bin/orangu/commands/mod.rs
@@ -137,9 +137,13 @@ pub enum CommandOutcome {
     /// Switch to the open workspace tab at the given full-order index
     /// (`/workspace <number>`).
     SwitchWorkspaceTab(usize),
-    /// Open a directory as a workspace tab, or switch to it if already open
-    /// (`/workspace <path>`).
+    /// Switch the active tab's workspace to the given path in-place, or switch
+    /// to the existing tab that already has it open (`/workspace <path>`).
+    ChangeWorkspace(PathBuf),
+    /// Open the given directory in a new workspace tab (`create workspace <dir>`).
     OpenWorkspaceTab(PathBuf),
+    /// Close the current workspace tab (`delete workspace`).
+    CloseWorkspaceTab,
     Blocking(Box<dyn FnOnce() -> anyhow::Result<String> + Send + 'static>),
     /// A long-running command that streams its output line by line through the
     /// sink as it is produced, rather than returning it all at once.
@@ -369,6 +373,10 @@ pub enum LocalCommand<'a> {
     /// (or switch to) that directory. The number-vs-path split happens in
     /// dispatch, mirroring how `Session` disambiguates its argument.
     Workspace(Option<Cow<'a, str>>),
+    /// `create workspace <dir>`: open a new tab for the given directory.
+    CreateWorkspace(Cow<'a, str>),
+    /// `delete workspace`: close the current workspace tab.
+    DeleteWorkspace,
     Export(ExportTarget),
     Manual,
     Usage,

--- a/src/bin/orangu/commands/natural.rs
+++ b/src/bin/orangu/commands/natural.rs
@@ -141,6 +141,10 @@ pub const NATURAL_LANGUAGE_BINDINGS: &[&str] = &[
     "add comment on ",
     "add comment to ",
     "comment on ",
+    // --- create workspace ---
+    "create workspace ",
+    // --- delete workspace ---
+    "delete workspace",
     // --- create pull request ---
     "pull request",
     "create pull request",
@@ -796,6 +800,12 @@ pub fn parse_natural_language_command(input: &str) -> Option<LocalCommand<'_>> {
         &["squash", "squash branch", "squash commits", "git squash"],
     ) {
         return Some(LocalCommand::Squash);
+    }
+    if let Some(rest) = strip_ascii_prefix(input, "create workspace ") {
+        return Some(LocalCommand::CreateWorkspace(Cow::Borrowed(rest.trim())));
+    }
+    if matches_ci(input, &["delete workspace"]) {
+        return Some(LocalCommand::DeleteWorkspace);
     }
     if matches_ci(input, &["delete", "delete branch"]) {
         return Some(LocalCommand::Branch(BranchSubcommand::List));

--- a/src/bin/orangu/commands/slash.rs
+++ b/src/bin/orangu/commands/slash.rs
@@ -78,6 +78,7 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
         "/stash" => Some(LocalCommand::Stash(StashSubcommand::Push)),
         "/bisect" => Some(LocalCommand::Bisect(BisectSubcommand::Status)),
         "/status" => Some(LocalCommand::Status),
+        "/create" => Some(LocalCommand::CreateWorkspace(Cow::Borrowed(""))),
         "/manual" => Some(LocalCommand::Manual),
         "/usage" => Some(LocalCommand::Usage),
         "/clear" => Some(LocalCommand::Clear),
@@ -305,8 +306,17 @@ pub fn parse_slash_command(input: &str) -> Option<LocalCommand<'_>> {
             if let Some(sub) = input.strip_prefix("/bisect ") {
                 return Some(LocalCommand::Bisect(parse_bisect_subcommand(sub)));
             }
+            if let Some(sub) = input.strip_prefix("/create ") {
+                let sub = sub.trim();
+                if let Some(dir) = sub.strip_prefix("workspace") {
+                    return Some(LocalCommand::CreateWorkspace(Cow::Borrowed(dir.trim())));
+                }
+            }
             if let Some(args) = input.strip_prefix("/delete ") {
                 let branch = args.trim();
+                if branch.eq_ignore_ascii_case("workspace") {
+                    return Some(LocalCommand::DeleteWorkspace);
+                }
                 if !branch.is_empty() {
                     return Some(LocalCommand::Branch(BranchSubcommand::Delete(
                         Cow::Borrowed(branch),

--- a/src/bin/orangu/commands/tests.rs
+++ b/src/bin/orangu/commands/tests.rs
@@ -1348,6 +1348,88 @@ fn parses_pending_commands() {
     }
 }
 
+/// `create workspace <dir>` and `delete workspace` parse into the correct
+/// variants and do not shadow branch deletion for any other argument.
+#[test]
+fn parses_create_and_delete_workspace_commands() {
+    // Bare /create (no argument yet) triggers the CreateWorkspace ghost.
+    assert!(matches!(
+        parse_local_command("/create"),
+        Some(LocalCommand::CreateWorkspace(ref dir)) if dir.is_empty()
+    ));
+
+    // /create workspace with and without a path.
+    assert!(matches!(
+        parse_local_command("/create workspace"),
+        Some(LocalCommand::CreateWorkspace(ref dir)) if dir.is_empty()
+    ));
+    match parse_local_command("/create workspace ~/project") {
+        Some(LocalCommand::CreateWorkspace(dir)) => assert_eq!(dir.as_ref(), "~/project"),
+        _ => panic!("expected /create workspace ~/project"),
+    }
+    match parse_local_command("/create workspace /abs/path") {
+        Some(LocalCommand::CreateWorkspace(dir)) => assert_eq!(dir.as_ref(), "/abs/path"),
+        _ => panic!("expected /create workspace /abs/path"),
+    }
+
+    // /create with an unrecognised subcommand must not match.
+    assert!(parse_local_command("/create session").is_none());
+
+    // /delete workspace (case-insensitive) closes the current tab.
+    for input in [
+        "/delete workspace",
+        "/delete WORKSPACE",
+        "/delete Workspace",
+    ] {
+        assert!(
+            matches!(
+                parse_local_command(input),
+                Some(LocalCommand::DeleteWorkspace)
+            ),
+            "expected {input:?} to parse as DeleteWorkspace"
+        );
+    }
+
+    // /delete <branch> still routes to branch deletion, never workspace close.
+    assert!(matches!(
+        parse_local_command("/delete feature/foo"),
+        Some(LocalCommand::Branch(BranchSubcommand::Delete(_)))
+    ));
+    // The literal string "workspace" as a branch name would be odd, but /delete
+    // must intercept it as DeleteWorkspace rather than branch-delete.
+    assert!(matches!(
+        parse_local_command("/delete workspace"),
+        Some(LocalCommand::DeleteWorkspace)
+    ));
+
+    // Natural-language: `create workspace <dir>`.
+    match parse_local_command("create workspace ~/project") {
+        Some(LocalCommand::CreateWorkspace(dir)) => assert_eq!(dir.as_ref(), "~/project"),
+        _ => panic!("expected natural 'create workspace ~/project'"),
+    }
+    match parse_local_command("CREATE WORKSPACE /abs/path") {
+        Some(LocalCommand::CreateWorkspace(dir)) => assert_eq!(dir.as_ref(), "/abs/path"),
+        _ => panic!("expected case-insensitive natural create workspace"),
+    }
+
+    // Natural-language: `delete workspace`.
+    for input in ["delete workspace", "Delete Workspace", "DELETE WORKSPACE"] {
+        assert!(
+            matches!(
+                parse_local_command(input),
+                Some(LocalCommand::DeleteWorkspace)
+            ),
+            "expected {input:?} to parse as DeleteWorkspace"
+        );
+    }
+
+    // `delete <branch>` must still work in the natural-language path.
+    assert!(matches!(
+        parse_local_command("delete feature/foo"),
+        Some(LocalCommand::Branch(BranchSubcommand::Delete(_)))
+    ));
+}
+
 /// `/bisect` and its natural-language aliases parse into the right
 /// [`BisectSubcommand`], covering the optional commit/rev arguments, the
 /// case-insensitive and whitespace-tolerant slash forms, and the fall-through

--- a/src/bin/orangu/completion/mod.rs
+++ b/src/bin/orangu/completion/mod.rs
@@ -79,6 +79,7 @@ pub const COMMANDS: &[&str] = &[
     "/pending",
     "/session",
     "/workspace",
+    "/create",
     "/manual",
     "/usage",
     "/build",
@@ -262,6 +263,23 @@ fn structured_completion_candidates(
 
     if let Some((start, candidates)) = export_completion_candidates(prefix) {
         return Some((start, cursor, candidates));
+    }
+
+    // `/create workspace <dir>`: mirror the same completion logic as `/workspace
+    // <dir>` — previously-seen workspace paths first, then filesystem directory
+    // completion for paths starting with `~`, `/`, or `.`.
+    if prefix == "/create " {
+        return Some(("/create ".len(), cursor, vec!["workspace".to_string()]));
+    }
+    if let Some(arg_prefix) = prefix.strip_prefix("/create workspace ") {
+        let mut candidates: Vec<String> = session_workspaces_newest_first()
+            .into_iter()
+            .filter(|w| w.starts_with(arg_prefix))
+            .collect();
+        if candidates.is_empty() {
+            candidates = session_path_completion_candidates(arg_prefix);
+        }
+        return Some(("/create workspace ".len(), cursor, candidates));
     }
 
     if let Some((start, candidates)) = checkout_completion_candidates(prefix, workspace) {

--- a/src/bin/orangu/dispatch.rs
+++ b/src/bin/orangu/dispatch.rs
@@ -662,10 +662,10 @@ pub(crate) fn handle_command(
                 }
                 return Ok(CommandOutcome::SwitchWorkspaceTab(number - 1));
             }
-            // Otherwise the argument is a directory: open it as a tab, or switch
-            // to it if it is already open.
+            // Otherwise the argument is a directory: switch the current tab's
+            // workspace to it in-place, or switch to an existing tab if open.
             match resolve_existing_dir_arg(arg) {
-                Some(dir) => Ok(CommandOutcome::OpenWorkspaceTab(dir)),
+                Some(dir) => Ok(CommandOutcome::ChangeWorkspace(dir)),
                 None => Ok(CommandOutcome::OutputError(format!(
                     "No such directory: {arg}"
                 ))),
@@ -680,6 +680,21 @@ pub(crate) fn handle_command(
                 Err(err) => Ok(local_command_error(err)),
             }
         }
+        LocalCommand::CreateWorkspace(dir) => {
+            let dir = dir.trim();
+            if dir.is_empty() {
+                return Ok(CommandOutcome::OutputError(
+                    "Usage: create workspace <directory>".to_string(),
+                ));
+            }
+            match resolve_existing_dir_arg(dir) {
+                Some(path) => Ok(CommandOutcome::OpenWorkspaceTab(path)),
+                None => Ok(CommandOutcome::OutputError(format!(
+                    "No such directory: {dir}"
+                ))),
+            }
+        }
+        LocalCommand::DeleteWorkspace => Ok(CommandOutcome::CloseWorkspaceTab),
         LocalCommand::Export(target) => Ok(CommandOutcome::Export(target)),
         LocalCommand::Manual => Ok(CommandOutcome::Manual),
         LocalCommand::Usage => Ok(CommandOutcome::Output(usage_stats.format())),
@@ -1040,12 +1055,12 @@ mod tests {
             CommandOutcome::OutputError(_)
         ));
 
-        // An existing directory opens (or switches to) a tab for it.
+        // An existing directory switches the current tab's workspace in-place.
         match run(&format!("/workspace {}", other.path().display())) {
-            CommandOutcome::OpenWorkspaceTab(dir) => {
+            CommandOutcome::ChangeWorkspace(dir) => {
                 assert_eq!(dir, crate::normalize_path(other.path()));
             }
-            _ => panic!("expected a workspace tab open for a directory"),
+            _ => panic!("expected a workspace change for a directory"),
         }
 
         // A path that is not a directory is rejected.
@@ -1053,6 +1068,97 @@ mod tests {
             CommandOutcome::OutputError(message) => assert!(message.contains("No such directory")),
             _ => panic!("expected an error for a missing directory"),
         }
+    }
+
+    #[test]
+    fn create_workspace_and_delete_workspace_commands() {
+        let other = tempdir().expect("other workspace");
+        let here_dir = tempdir().expect("workspace");
+        let here = crate::normalize_path(here_dir.path());
+
+        let run = |input: &str| -> CommandOutcome {
+            let llms = HashMap::from([(
+                "llama".to_string(),
+                test_profile("llama.cpp", "http://localhost:8100/v1", "gemma"),
+            )]);
+            let tools = ToolExecutor::new(&here);
+            let mut active_model = "llama".to_string();
+            let mut active_model_id = "gemma".to_string();
+            let mut current_endpoint = Some(normalized_openai_endpoint("http://localhost:8100/v1"));
+            let mut session = ChatSession::new("system");
+            handle_command(
+                input,
+                CommandState {
+                    active_model: &mut active_model,
+                    active_model_id: &mut active_model_id,
+                    current_endpoint: &mut current_endpoint,
+                    session: &mut session,
+                    detect_model: &mut false,
+                },
+                CommandContext {
+                    skills: &orangu::skills::SkillRegistry::discover(std::path::Path::new("/")),
+                    startup_model: "llama",
+                    startup_endpoint: "http://localhost:8100/v1",
+                    llms: &llms,
+                    tools: &tools,
+                    workspace: &here,
+                    usage_stats: &super::UsageStats::new(),
+                    available_models: &[],
+                    virtual_width: 512,
+                    auto_rebase: false,
+                    auto_squash: false,
+                    terminal: "",
+                    forge: crate::git::Forge::GitHub,
+                    review_reports: crate::git::ReviewReports::default(),
+                },
+            )
+            .expect("handle command")
+        };
+
+        // An existing directory opens a new workspace tab.
+        match run(&format!("/create workspace {}", other.path().display())) {
+            CommandOutcome::OpenWorkspaceTab(dir) => {
+                assert_eq!(dir, crate::normalize_path(other.path()));
+            }
+            _ => panic!("expected OpenWorkspaceTab for an existing directory"),
+        }
+
+        // Natural-language form works too.
+        match run(&format!("create workspace {}", other.path().display())) {
+            CommandOutcome::OpenWorkspaceTab(dir) => {
+                assert_eq!(dir, crate::normalize_path(other.path()));
+            }
+            _ => panic!("expected OpenWorkspaceTab for natural-language create"),
+        }
+
+        // A non-existent directory is rejected.
+        assert!(matches!(
+            run("/create workspace /no/such/orangu/dir"),
+            CommandOutcome::OutputError(_)
+        ));
+
+        // Bare `/create` (no directory) shows a usage error.
+        assert!(matches!(run("/create"), CommandOutcome::OutputError(_)));
+
+        // `/delete workspace` closes the current tab.
+        assert!(matches!(
+            run("/delete workspace"),
+            CommandOutcome::CloseWorkspaceTab
+        ));
+
+        // Natural-language form closes the current tab.
+        assert!(matches!(
+            run("delete workspace"),
+            CommandOutcome::CloseWorkspaceTab
+        ));
+
+        // `/delete <branch>` still routes to branch deletion, not workspace close.
+        assert!(matches!(
+            run("/delete some-feature-branch"),
+            CommandOutcome::Output(_)
+                | CommandOutcome::OutputError(_)
+                | CommandOutcome::Blocking(_)
+        ));
     }
 
     #[test]

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -226,23 +226,57 @@ async fn run() -> Result<()> {
 
     // Open the first workspace tab (tab 1). Each tab is its own session; the
     // ring holds the others as the user opens more with `/workspace`/Alt+Insert.
-    let initial_tab = WorkspaceTab::open(
-        resolve_workspace_root(args.workspace)?,
-        args.resume.as_deref(),
-        true,
+    //
+    // When -a is given without an explicit --workspace/--resume, the first
+    // entry in ~/.orangu/workspaces is opened with its exact session ID so
+    // the -a loop can reliably skip it by ID and never creates a duplicate tab.
+    let saved_workspaces = if args.all {
+        load_open_workspaces()
+    } else {
+        vec![]
+    };
+    let (initial_workspace, initial_session) =
+        if args.all && args.workspace.is_none() && args.resume.is_none() {
+            if let Some((ws, sess)) = saved_workspaces.first() {
+                (ws.clone(), sess.clone())
+            } else {
+                (resolve_workspace_root(None)?, None)
+            }
+        } else {
+            (resolve_workspace_root(args.workspace)?, None)
+        };
+    let mut initial_tab = WorkspaceTab::open(
+        initial_workspace,
+        initial_session.as_deref().or(args.resume.as_deref()),
+        initial_session.is_none() && args.resume.is_none(),
         &system_prompt,
     )?;
+    // Load the initial tab's branch from session metadata so that Alt+./, and
+    // checkout_tab_branch! can restore the right branch on next tab switch.
+    if let Some(branch) = load_session_branch(&initial_tab.session_id) {
+        initial_tab.current_branch = Some(branch);
+    }
     let mut ring = WorkspaceRing::new();
-    // If -a/--all, reopen the workspace tabs that were open at the end of the
-    // last run. Skip paths that equal the initial workspace (already open) and
-    // silently ignore tabs whose directories have since been deleted.
-    if args.all {
-        for saved_workspace in load_open_workspaces() {
-            if saved_workspace != initial_tab.workspace
-                && let Ok(tab) = WorkspaceTab::open(saved_workspace, None, true, &system_prompt)
-            {
-                ring.park(tab);
+    // Reopen the remaining saved tabs as parked tabs, skipping the initial one.
+    for (saved_workspace, saved_session) in &saved_workspaces {
+        let is_initial = match saved_session {
+            Some(id) => *id == initial_tab.session_id,
+            None => *saved_workspace == initial_tab.workspace,
+        };
+        if !is_initial
+            && let Ok(mut tab) = WorkspaceTab::open(
+                saved_workspace.clone(),
+                saved_session.as_deref(),
+                saved_session.is_none(),
+                &system_prompt,
+            )
+        {
+            // Branch stored in session metadata takes precedence over the
+            // current git branch so Alt+./, restores the right branch.
+            if let Some(branch) = load_session_branch(&tab.session_id) {
+                tab.current_branch = Some(branch);
             }
+            ring.park(tab);
         }
     }
 
@@ -387,33 +421,25 @@ async fn run() -> Result<()> {
         ($action:expr) => {{
             match $action {
                 TabAction::Next => {
+                    current_branch = workspace_branch_name(tools.workspace());
                     let target = ring.rotate(current_tab!(), 1);
                     load_tab!(target);
+                    checkout_tab_branch!();
                 }
                 TabAction::Previous => {
+                    current_branch = workspace_branch_name(tools.workspace());
                     let target = ring.rotate(current_tab!(), -1);
                     load_tab!(target);
+                    checkout_tab_branch!();
                 }
                 TabAction::SwitchTo(index) => {
                     if index >= ring.total() {
                         output_state.push_text(&format!("No workspace {} is open.", index + 1));
                     } else {
+                        current_branch = workspace_branch_name(tools.workspace());
                         let target = ring.switch_to(current_tab!(), index);
                         load_tab!(target);
-                    }
-                }
-                TabAction::Open(path) => {
-                    if let Some(index) = ring.position_of(&workspace, &path) {
-                        let target = ring.switch_to(current_tab!(), index);
-                        load_tab!(target);
-                    } else {
-                        match WorkspaceTab::open(path, None, true, &system_prompt) {
-                            Ok(new_tab) => {
-                                let target = ring.open(current_tab!(), new_tab);
-                                load_tab!(target);
-                            }
-                            Err(err) => output_state.push_text(&format!("Error: {err:#}")),
-                        }
+                        checkout_tab_branch!();
                     }
                 }
                 TabAction::New => {
@@ -436,10 +462,50 @@ async fn run() -> Result<()> {
                         // `total > 1` guarantees a neighbour to focus.
                         let target = ring.close(parked).expect("more than one tab is open");
                         load_tab!(target);
+                        checkout_tab_branch!();
                     }
                 }
             }
             output_state.reset_scroll();
+        }};
+    }
+    // After loading a new tab (Next/Previous/SwitchTo/Close), switch the git
+    // repo to the branch that was active when that tab was last used.  Skips
+    // workspaces without a git root or when the branch is already correct.
+    //
+    // MUST be called after load_tab! so that `workspace`, `tools`, and
+    // `current_branch` all refer to the incoming (newly active) tab.
+    macro_rules! checkout_tab_branch {
+        () => {
+            if let Some(branch) = &current_branch {
+                if discover_git_root(&workspace).is_some()
+                    && workspace_branch_name(&workspace).as_deref() != Some(branch.as_str())
+                {
+                    if let Err(err) = git_checkout(&workspace, branch) {
+                        output_state.push_text(&format!("branch switch: {err:#}"));
+                    }
+                }
+            }
+        };
+    }
+    // Restart the per-workspace background tasks (default-branch sync, open PRs,
+    // issue metadata) after the active workspace changes. Called after load_tab!
+    // so `tools.workspace()` already points at the new workspace.
+    macro_rules! restart_sync_tasks {
+        () => {{
+            sync_notice = None;
+            sync_handle = discover_git_root(tools.workspace()).map(|_| {
+                let w = tools.workspace().to_path_buf();
+                tokio::task::spawn_blocking(move || sync_default_branch(&w, forge))
+            });
+            pr_handle = discover_git_root(tools.workspace()).map(|_| {
+                let w = tools.workspace().to_path_buf();
+                tokio::task::spawn_blocking(move || fetch_active_pull_requests(&w, forge))
+            });
+            issue_meta_handle = discover_git_root(tools.workspace()).map(|_| {
+                let w = tools.workspace().to_path_buf();
+                tokio::task::spawn_blocking(move || fetch_issue_metadata(&w, forge))
+            });
         }};
     }
     // Persist every open tab on exit so each one stays resumable — the active
@@ -448,13 +514,24 @@ async fn run() -> Result<()> {
     macro_rules! save_all_tabs {
         () => {{
             save_session_messages(&session_messages_path, session.messages())?;
-            update_session_metadata_timestamp(&session_metadata_path)?;
+            let active_branch = workspace_branch_name(tools.workspace());
+            update_session_metadata_branch(&session_metadata_path, active_branch.as_deref())?;
             for tab in ring.parked() {
                 let _ = tab.save();
             }
             {
-                let mut all_workspaces = vec![workspace.clone()];
-                all_workspaces.extend(ring.parked().iter().map(|t| t.workspace.clone()));
+                let active_pos = ring.active_pos();
+                let all_workspaces: Vec<(PathBuf, String)> = (0..ring.total())
+                    .map(|pos| {
+                        if pos == active_pos {
+                            (workspace.clone(), session_id.clone())
+                        } else {
+                            let idx = if pos < active_pos { pos } else { pos - 1 };
+                            let tab = &ring.parked()[idx];
+                            (tab.workspace.clone(), tab.session_id.clone())
+                        }
+                    })
+                    .collect();
                 save_open_workspaces(&all_workspaces);
             }
         }};
@@ -895,7 +972,62 @@ async fn run() -> Result<()> {
                 continue;
             }
             CommandOutcome::OpenWorkspaceTab(dir) => {
-                pending_tab_action = Some(TabAction::Open(dir));
+                // If the directory is already open in another tab, focus it rather
+                // than creating a duplicate.
+                if let Some(index) = ring.position_of(&workspace, &dir) {
+                    pending_tab_action = Some(TabAction::SwitchTo(index));
+                    continue;
+                }
+                let _ = save_session_messages(&session_messages_path, session.messages());
+                let _ = update_session_metadata_branch(
+                    &session_metadata_path,
+                    workspace_branch_name(tools.workspace()).as_deref(),
+                );
+                match WorkspaceTab::open(dir, None, true, &system_prompt) {
+                    Ok(new_tab) => {
+                        let target = ring.open(current_tab!(), new_tab);
+                        load_tab!(target);
+                        restart_sync_tasks!();
+                        output_state.reset_scroll();
+                    }
+                    Err(err) => {
+                        output_state.push_text(&format!("Error: {err:#}"));
+                        if config.feedback {
+                            output_state.push_text(FEEDBACK_ERR);
+                        }
+                        output_state.reset_scroll();
+                    }
+                }
+                continue;
+            }
+            CommandOutcome::CloseWorkspaceTab => {
+                pending_tab_action = Some(TabAction::Close);
+                continue;
+            }
+            CommandOutcome::ChangeWorkspace(dir) => {
+                if let Some(index) = ring.position_of(&workspace, &dir) {
+                    pending_tab_action = Some(TabAction::SwitchTo(index));
+                } else {
+                    let _ = save_session_messages(&session_messages_path, session.messages());
+                    let _ = update_session_metadata_branch(
+                        &session_metadata_path,
+                        workspace_branch_name(tools.workspace()).as_deref(),
+                    );
+                    match WorkspaceTab::open(dir, None, true, &system_prompt) {
+                        Ok(new_tab) => {
+                            load_tab!(new_tab);
+                            restart_sync_tasks!();
+                            output_state.reset_scroll();
+                        }
+                        Err(err) => {
+                            output_state.push_text(&format!("Error: {err:#}"));
+                            if config.feedback {
+                                output_state.push_text(FEEDBACK_ERR);
+                            }
+                            output_state.reset_scroll();
+                        }
+                    }
+                }
                 continue;
             }
             CommandOutcome::Quiet => {

--- a/src/bin/orangu/session_store.rs
+++ b/src/bin/orangu/session_store.rs
@@ -47,53 +47,62 @@ fn open_workspaces_path() -> Option<PathBuf> {
     Some(home::home_dir()?.join(OPEN_WORKSPACES_FILE))
 }
 
-/// Record the open workspace directories, one per line, so `orangu -a` can
-/// reopen them next time. Errors are ignored: failing to save the layout must
-/// never block exit.
-pub(crate) fn save_open_workspaces(workspaces: &[PathBuf]) {
+/// Record the open workspace directories and session IDs, one per line, so
+/// `orangu -a` can reopen them next time.  Branch information is stored in
+/// each session's metadata file instead.  Errors are ignored: failing to save
+/// the layout must never block exit.
+pub(crate) fn save_open_workspaces(workspaces: &[(PathBuf, String)]) {
     let Some(path) = open_workspaces_path() else {
         return;
     };
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    let _ = std::fs::write(&path, format_workspace_paths(workspaces));
+    let _ = std::fs::write(&path, format_workspace_entries(workspaces));
 }
 
-fn format_workspace_paths(workspaces: &[PathBuf]) -> String {
+/// Format is `<path>\t<session-id>\n` per entry.  Every entry ends with a
+/// newline so the file is a well-formed POSIX text file.
+fn format_workspace_entries(workspaces: &[(PathBuf, String)]) -> String {
     use std::fmt::Write as FmtWrite;
     let mut body = String::new();
-    for (i, workspace) in workspaces.iter().enumerate() {
-        if i > 0 {
-            body.push('\n');
-        }
-        write!(body, "{}", workspace.display()).ok();
+    for (workspace, session_id) in workspaces {
+        writeln!(body, "{}\t{}", workspace.display(), session_id).ok();
     }
     body
 }
 
-/// The workspace directories saved by the last run that still exist, in order.
-/// Read by `orangu -a|--all`; missing directories are skipped so a deleted
-/// project does not get recreated on restore.
-pub(crate) fn load_open_workspaces() -> Vec<PathBuf> {
+/// The workspace directories and session IDs saved by the last run that still
+/// exist, in tab-bar order.  Read by `orangu -a|--all`; missing directories
+/// are skipped so a deleted project does not get recreated.
+///
+/// Accepts two formats for backward compatibility with pre-session-ID files:
+/// - `<path>\t<session-id>` (current format)
+/// - `<path>` (path-only, session auto-resumed on open)
+pub(crate) fn load_open_workspaces() -> Vec<(PathBuf, Option<String>)> {
     let Some(path) = open_workspaces_path() else {
         return Vec::new();
     };
     let Ok(contents) = std::fs::read_to_string(&path) else {
         return Vec::new();
     };
-    parse_workspace_paths(&contents)
+    parse_workspace_entries(&contents)
         .into_iter()
-        .filter(|workspace| workspace.is_dir())
+        .filter(|(workspace, _)| workspace.is_dir())
         .collect()
 }
 
-fn parse_workspace_paths(contents: &str) -> Vec<PathBuf> {
+fn parse_workspace_entries(contents: &str) -> Vec<(PathBuf, Option<String>)> {
     contents
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty())
-        .map(PathBuf::from)
+        .map(|line| {
+            let mut parts = line.splitn(2, '\t');
+            let path = PathBuf::from(parts.next().unwrap_or(""));
+            let session_id = parts.next().filter(|s| !s.is_empty()).map(str::to_string);
+            (path, session_id)
+        })
         .collect()
 }
 
@@ -102,56 +111,119 @@ mod tests {
     use super::*;
 
     #[test]
-    fn format_workspace_paths_joins_with_newlines() {
-        let paths = vec![
-            PathBuf::from("/home/user/project"),
-            PathBuf::from("/home/user/other"),
+    fn format_workspace_entries_writes_two_fields_with_trailing_newline() {
+        let entries = vec![
+            (PathBuf::from("/home/user/project"), "uuid-1".to_string()),
+            (PathBuf::from("/home/user/other"), "uuid-2".to_string()),
         ];
-        let body = format_workspace_paths(&paths);
-        assert_eq!(body, "/home/user/project\n/home/user/other");
-    }
-
-    #[test]
-    fn format_workspace_paths_single_entry_has_no_trailing_newline() {
-        let paths = vec![PathBuf::from("/a")];
-        assert_eq!(format_workspace_paths(&paths), "/a");
-    }
-
-    #[test]
-    fn format_workspace_paths_empty_produces_empty_string() {
-        assert_eq!(format_workspace_paths(&[]), "");
-    }
-
-    #[test]
-    fn parse_workspace_paths_splits_lines() {
-        let body = "/home/user/project\n/home/user/other";
-        let paths = parse_workspace_paths(body);
+        let body = format_workspace_entries(&entries);
         assert_eq!(
-            paths,
+            body,
+            "/home/user/project\tuuid-1\n/home/user/other\tuuid-2\n"
+        );
+    }
+
+    #[test]
+    fn format_workspace_entries_empty_produces_empty_string() {
+        assert_eq!(format_workspace_entries(&[]), "");
+    }
+
+    #[test]
+    fn parse_workspace_entries_reads_two_field_format() {
+        let body = "/home/user/project\tuuid-1\n/home/user/other\tuuid-2\n";
+        let entries = parse_workspace_entries(body);
+        assert_eq!(
+            entries,
             [
-                PathBuf::from("/home/user/project"),
-                PathBuf::from("/home/user/other"),
+                (
+                    PathBuf::from("/home/user/project"),
+                    Some("uuid-1".to_string())
+                ),
+                (
+                    PathBuf::from("/home/user/other"),
+                    Some("uuid-2".to_string())
+                ),
             ]
         );
     }
 
     #[test]
-    fn parse_workspace_paths_skips_blank_lines() {
-        let body = "/a\n\n  \n/b";
-        let paths = parse_workspace_paths(body);
-        assert_eq!(paths, [PathBuf::from("/a"), PathBuf::from("/b")]);
+    fn parse_workspace_entries_accepts_old_path_only_format() {
+        let body = "/a\n/b\n";
+        let entries = parse_workspace_entries(body);
+        assert_eq!(
+            entries,
+            [(PathBuf::from("/a"), None), (PathBuf::from("/b"), None),]
+        );
+    }
+
+    #[test]
+    fn parse_workspace_entries_skips_blank_lines() {
+        let body = "/a\tuuid-1\n\n  \n/b\tuuid-2\n";
+        let entries = parse_workspace_entries(body);
+        assert_eq!(
+            entries,
+            [
+                (PathBuf::from("/a"), Some("uuid-1".to_string())),
+                (PathBuf::from("/b"), Some("uuid-2".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn update_session_metadata_branch_persists_and_load_session_branch_retrieves() {
+        use tempfile::tempdir;
+        let dir = tempdir().expect("temp dir");
+        let meta_path = dir.path().join("metadata");
+
+        // Write a minimal metadata file so update/load have something to work with.
+        let initial = SessionMetadata {
+            started_at: 1_000_000,
+            last_updated_at: 1_000_000,
+            workspace: "/some/workspace".to_string(),
+            branch: String::new(),
+        };
+        save_session_metadata(&meta_path, &initial).expect("save initial");
+
+        // A session ID that resolves to our temp directory does not exist in the
+        // standard location, so load_session_branch can only be tested via the
+        // lower-level update/load pair here.
+        update_session_metadata_branch(&meta_path, Some("feature/test-branch"))
+            .expect("update branch");
+
+        let loaded = load_session_metadata(&meta_path)
+            .expect("read ok")
+            .expect("metadata present");
+        assert_eq!(loaded.branch, "feature/test-branch");
+        // last_updated_at must have been bumped.
+        assert!(loaded.last_updated_at >= initial.last_updated_at);
+
+        // Setting branch to None leaves the existing value unchanged.
+        update_session_metadata_branch(&meta_path, None).expect("no-op update");
+        let after_noop = load_session_metadata(&meta_path)
+            .expect("read ok")
+            .expect("metadata present");
+        assert_eq!(after_noop.branch, "feature/test-branch");
+
+        // An empty string branch via Some("") should still write an empty branch.
+        update_session_metadata_branch(&meta_path, Some("")).expect("clear branch");
+        let after_clear = load_session_metadata(&meta_path)
+            .expect("read ok")
+            .expect("metadata present");
+        assert_eq!(after_clear.branch, "");
     }
 
     #[test]
     fn format_and_parse_round_trip() {
         let original = vec![
-            PathBuf::from("/workspace/alpha"),
-            PathBuf::from("/workspace/beta"),
-            PathBuf::from("/workspace/gamma"),
+            (PathBuf::from("/workspace/alpha"), "aaa-111".to_string()),
+            (PathBuf::from("/workspace/beta"), "bbb-222".to_string()),
         ];
-        let serialized = format_workspace_paths(&original);
-        let parsed = parse_workspace_paths(&serialized);
-        assert_eq!(parsed, original);
+        let serialized = format_workspace_entries(&original);
+        let parsed = parse_workspace_entries(&serialized);
+        let expected: Vec<(PathBuf, Option<String>)> =
+            original.into_iter().map(|(p, id)| (p, Some(id))).collect();
+        assert_eq!(parsed, expected);
     }
 }
 
@@ -300,12 +372,32 @@ pub(crate) fn load_session_metadata(path: &Path) -> Result<Option<SessionMetadat
     }
 }
 
-pub(crate) fn update_session_metadata_timestamp(path: &Path) -> Result<()> {
+/// Update both `last_updated_at` and `branch` in the session metadata file.
+/// When `branch` is `None` the branch field is left as-is.
+pub(crate) fn update_session_metadata_branch(path: &Path, branch: Option<&str>) -> Result<()> {
     if let Ok(Some(mut meta)) = load_session_metadata(path) {
         meta.last_updated_at = current_unix_timestamp();
+        if let Some(b) = branch {
+            meta.branch = b.to_string();
+        }
         save_session_metadata(path, &meta)?;
     }
     Ok(())
+}
+
+/// Read the `branch` field from `~/.orangu/sessions/<session_id>/metadata`.
+/// Returns `None` when the session doesn't exist, the file can't be read, or
+/// the branch field is empty (the session was started outside a git repo).
+pub(crate) fn load_session_branch(session_id: &str) -> Option<String> {
+    let path = session_dir_path(session_id).ok()?;
+    let meta = load_session_metadata(&path.join("metadata"))
+        .ok()
+        .flatten()?;
+    if meta.branch.is_empty() {
+        None
+    } else {
+        Some(meta.branch)
+    }
 }
 
 pub(crate) fn find_session_for_workspace_branch(workspace: &str, branch: &str) -> Option<String> {

--- a/src/bin/orangu/workspace_tab.rs
+++ b/src/bin/orangu/workspace_tab.rs
@@ -189,7 +189,10 @@ impl WorkspaceTab {
         if self.pending_response.is_none() {
             save_session_messages(&self.session_messages_path, self.session.messages())?;
         }
-        update_session_metadata_timestamp(&self.session_metadata_path)?;
+        update_session_metadata_branch(
+            &self.session_metadata_path,
+            self.current_branch.as_deref(),
+        )?;
         Ok(())
     }
 
@@ -336,9 +339,6 @@ pub(crate) enum TabAction {
     Previous,
     /// Focus the tab at the given full-order index (`/workspace <number>`).
     SwitchTo(usize),
-    /// Open `path` as a new tab, or switch to it if already open
-    /// (`/workspace <path>`).
-    Open(PathBuf),
     /// Start a fresh tab on the active workspace's directory (`Alt+Insert`); the
     /// user re-points it with `/workspace` afterwards.
     New,


### PR DESCRIPTION
`/workspace <dir>` now replaces the active tab's workspace in-place instead of opening a new tab.  If the directory is already open in another tab the command switches to that tab instead.  Background git-sync, PR, and issue-metadata tasks are restarted for the new workspace on every in-place switch.

`save_all_tabs!` previously wrote workspaces in [active, parked...] order regardless of tab-bar position.  It now reconstructs the left-to-right tab-bar order so `orangu -a` restores tabs in the same visual arrangement they were in at exit.

`TabAction::Open` and `CommandOutcome::OpenWorkspaceTab` are removed; the new `CommandOutcome::ChangeWorkspace` replaces both.