### PR TITLE
[#137] Handle unsupported keyboard enhancement on Windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Jesper Pedersen <jesperpedersen.db@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Tejas Singh Bhati <tejassinghbhati077@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
+Nishant raj Jha <nishantrajx924@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -11,6 +11,7 @@ Jesper Pedersen <jesperpedersen.db@gmail.com>
 Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Tejas Singh Bhati <tejassinghbhati077@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
+Nishant raj Jha <nishantrajx924@gmail.com>
 ```
 
 ## Committers

--- a/src/bin/orangu/terminal.rs
+++ b/src/bin/orangu/terminal.rs
@@ -53,11 +53,13 @@ pub(crate) struct TerminalUiGuard;
 impl TerminalUiGuard {
     pub(crate) fn new() -> Result<Self> {
         enable_raw_mode()?;
-        execute!(
+        execute!(std::io::stdout(), EnterAlternateScreen)?;
+        // Keyboard enhancement is not supported on all terminals (e.g. Windows legacy console).
+        // If it fails, we gracefully ignore the error.
+        let _ = execute!(
             std::io::stdout(),
-            EnterAlternateScreen,
             PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
-        )?;
+        );
         Ok(Self)
     }
 }


### PR DESCRIPTION
### Summary

This change prevents Orangu from aborting startup when keyboard enhancement is unavailable.

### What changed

* Keep `EnterAlternateScreen` as a required initialization step.
* Execute `PushKeyboardEnhancementFlags` separately.
* Treat failure to enable keyboard enhancement as non-fatal so the UI can still start.

### Testing

Tested on:

* Windows 11 (10.0.26200.8655)
* Windows Terminal
* Rust MSVC toolchain
* Ollama 0.30.10
* Model: `gemma4:e4b`

Before this change:

```text
error: Keyboard progressive enhancement not implemented for the legacy Windows API.
```

The application exited immediately.

After this change:

* The interactive UI starts successfully.
* Ollama connects correctly.
* The application is usable.

Fixes #137.
