### PR TITLE
Fix docs publish pipeline: PAT auth, link references, and image assets

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -23,12 +23,18 @@ jobs:
           mkdir -p target/web-doc
           MANUAL=doc/manual/en
           TMPL=doc/manual/web-template.html
+          # The link reference definitions ([orangu], [llama], community links,
+          # etc.) live in 99-references.md. Pandoc resolves reference-style links
+          # only when that file is supplied alongside each page, so it is passed
+          # as a second input to every conversion; otherwise the links render as
+          # raw "[text][ref]" text.
+          REFS="$MANUAL/99-references.md"
           PANDOC="pandoc --template $TMPL --toc --toc-depth=2 -f markdown-smart+raw_tex -t html5"
 
           # source file:output page:page title
           while IFS=: read -r src out title; do
             src=$(echo "$src" | xargs); out=$(echo "$out" | xargs); title=$(echo "$title" | xargs)
-            $PANDOC "$MANUAL/$src" --metadata "title=$title" -o "target/web-doc/$out"
+            $PANDOC "$MANUAL/$src" "$REFS" --metadata "title=$title" -o "target/web-doc/$out"
             echo "  $src → $out"
           done <<'PAGES'
           01-introduction.md:introduction.html:Introduction
@@ -44,15 +50,25 @@ jobs:
           73-openai.md:local-llm.html:Local LLM
           PAGES
 
-      - name: Push to website repo
-        env:
-          WEBSITE_PAT: ${{ secrets.WEBSITE_PAT }}
+      # Check out the website repo with the PAT. actions/checkout passes the
+      # token as a base64 Authorization header rather than inlining it in the
+      # clone URL, so tokens containing URL-significant characters (#, @, /)
+      # can never corrupt the remote URL.
+      - name: Check out website repo
+        uses: actions/checkout@v5
+        with:
+          repository: mnemosyne-systems/mnemosyne-systems.github.io
+          token: ${{ secrets.WEBSITE_PAT }}
+          path: website
+
+      - name: Commit and push docs
         run: |
           set -euo pipefail
-          git clone \
-            "https://x-access-token:${WEBSITE_PAT}@github.com/mnemosyne-systems/mnemosyne-systems.github.io.git" \
-            website
           cp target/web-doc/*.html website/orangu/doc/
+          # Copy manual images (e.g. the terminal screenshot referenced by the
+          # introduction) so image links resolve on the published pages.
+          mkdir -p website/orangu/doc/images
+          cp doc/images/*.png website/orangu/doc/images/
           cd website
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/doc/manual/web-template.html
+++ b/doc/manual/web-template.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>$title$ — orangu</title>
   <link rel="stylesheet" href="doc.css" />
+  <style>
+    .doc-content img { max-width: min(100%, 640px); height: auto; display: block; border-radius: 6px; margin: 1.25rem 0; }
+    .doc-content figcaption { font-size: 0.8rem; color: var(--text-2); margin-top: -0.75rem; margin-bottom: 1rem; }
+  </style>
   <script>document.documentElement.setAttribute('data-theme', localStorage.getItem('ou-theme') || 'dark');</script>
 </head>
 <body>


### PR DESCRIPTION
Repairs the `publish-docs` workflow so the website actually updates on tag push, and so the generated pages are correct.

## Why

The job failed on tag push with:

```
fatal: unable to access 'https://!fdRE$#hgYT56@github.com/.../mnemosyne-systems.github.io.git/': URL rejected: Bad hostname
```

The `WEBSITE_PAT` was inlined into the clone URL, so URL-significant characters in the token (`#`, `@`, `/`) corrupted it. Beyond that, the generated pages had two long-standing issues: reference-style links rendered as raw `[text][ref]`, and the introduction screenshot overflowed the column / was not copied to the site.

## Changes

- **Token via auth header.** Switch the website push to `actions/checkout` with `token:`, which passes the PAT as a base64 `Authorization` header instead of embedding it in the URL — immune to special characters.
- **Resolve link references.** Pass `doc/manual/en/99-references.md` as a second input to every `pandoc` conversion so reference-style links resolve.
- **Image sizing.** Restore the image-sizing `<style>` block in `web-template.html` (caps the terminal screenshot at 640px).
- **Copy image assets.** Copy `doc/images/*.png` into the site's `doc/images/`.

> Note: this still requires `WEBSITE_PAT` to be set to a valid GitHub token with write access to the website repo — the current secret value is not a real token.

Companion website PR with the regenerated 0.10.0 docs: mnemosyne-systems/mnemosyne-systems.github.io#9