### PR TITLE
[#163] Add idle timeout, config hot-reloading, fallback routing, and graceful shutdown

### DIFF
--- a/doc/COORDINATOR.md
+++ b/doc/COORDINATOR.md
@@ -82,6 +82,7 @@ dynamically per the routing order in [How it works](#how-it-works):
 | `GET /metrics` | *(none)* | Same as above |
 | `GET /v1/coordinator` | *(none — special)* | **Not pass-through.** Answered directly by the coordinator itself; see below |
 | `POST /v1/coordinator/activate` | Whatever `model` names | **Not pass-through.** A pre-warming hint, answered directly; see below |
+| `GET /v1/coordinator/shutdown` | *(none — special)* | **Not pass-through.** Cleanly terminates the proxy process and unloads the active model. Disabled unless `shutdown_token` is configured; requires `?token=<secret>` and a loopback source IP |
 
 The "currently active" fallback for the model-less rows matters in practice:
 without it, something like `/information` probing a server's `/health` would
@@ -178,6 +179,8 @@ llamacpp = llama-server -hf unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF --host loc
 | `port` | `[orangu-coordinator]` | No | Port the proxy listens on. Defaults to `9000` |
 | `startup_timeout` | `[orangu-coordinator]` | No | Seconds to wait for a newly started llama.cpp to answer `/v1/models` before giving up. Defaults to `180` |
 | `max_body_bytes` | `[orangu-coordinator]` | No | Request/response body size cap in bytes. Defaults to `67108864` (64 MiB) |
+| `idle_timeout` | `[orangu-coordinator]` | No | Seconds of inactivity before automatically unloading the active model to free system resources (RAM/VRAM). Disabled by default. |
+| `shutdown_token` | `[orangu-coordinator]` | No | Shared secret that enables the `GET /v1/coordinator/shutdown` endpoint. The caller must pass `?token=<value>` and connect from localhost. Disabled by default when absent. |
 | `role` | profile | No | Same roles as `orangu.conf`: `all` (default), `code`, `review`, `explorer`, `embeddings`. At least one profile must resolve to `all` — it's the fallback profile |
 | `llamacpp` | profile | Yes | Full shell-style command line used to start llama.cpp for this profile, e.g. `llama-server -hf org/Model-GGUF --host localhost --port 8100 --ctx-size 32768`. Parsed like a shell command line (quoting works, e.g. `--chat-template-kwargs '{"enable_thinking": false}'`), but run directly — no shell is invoked, so stopping the profile always stops the real `llama-server` process, not just a wrapper. Leading `KEY=VALUE` tokens (the shell convention for setting one-off variables before a command, e.g. `LLAMA_CACHE=/models llama-server ...`) are recognized explicitly and set as environment variables on the spawned process, since there's no real shell to interpret them. A leading `~` or `~/...` in any argument or `KEY=VALUE` value (e.g. `--slot-save-path ~/.orangu/llama-slots`) is expanded to the home directory for the same reason — a real shell would otherwise have done this automatically (`~otheruser` forms are not supported). There is no separate `model`, `host`, or `port` key: they're all read straight off this command line, so there's exactly one place each is named — `-hf`/`--hf-repo` or `-m`/`--model` for the model (required — profiles *may* share a model, e.g. the same model configured once per role; `resolve_entry` breaks any resulting tie by profile name), `--host`/`--port` for where the coordinator proxies to (default to `127.0.0.1:8080`, same as llama.cpp itself, when omitted) |
 | `api_key` | profile | No | Sent as `Authorization: Bearer <key>` on the coordinator's own requests to this profile's llama.cpp, if `llamacpp` starts it with `--api-key` |
@@ -274,6 +277,8 @@ coordinator. Behind a confirmed coordinator, those sections' own `role` and
 
 - The coordinator does not manage remote/already-running llama.cpp instances;
   `llamacpp` is always a command it spawns and owns the lifecycle of.
+- **Dynamic Hot-Reloading**: The coordinator watches `orangu-coordinator.conf` and hot-reloads changes automatically (polled every ~5 seconds) without needing a restart.
+- **Fallback Routing**: If a requested profile fails to load (e.g. out of memory), the coordinator automatically falls back to starting the `all`-role profile rather than failing the request entirely.
 - The first request after a swap waits for the new model to finish loading;
   size `startup_timeout` generously for large models.
 - Once orangu confirms it's talking to a coordinator, it shows "Automatic"

--- a/doc/manual/en/44-coordinator.md
+++ b/doc/manual/en/44-coordinator.md
@@ -72,6 +72,7 @@ llamacpp = llama-server -hf unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF --host loc
 | `port` | `[orangu-coordinator]` | No | Port the proxy listens on. Defaults to `9000` |
 | `startup_timeout` | `[orangu-coordinator]` | No | Seconds to wait for a newly started llama.cpp to answer `/v1/models` before giving up. Defaults to `180` |
 | `max_body_bytes` | `[orangu-coordinator]` | No | Request/response body size cap in bytes. Defaults to `67108864` (64 MiB) |
+| `idle_timeout` | `[orangu-coordinator]` | No | Seconds of inactivity before automatically unloading the active model to free system resources (RAM/VRAM). Disabled by default. |
 | `role` | profile | No | Same roles as `orangu.conf`: `all` (default), `code`, `review`, `explorer`, `embeddings`. At least one profile must resolve to `all` — it's the fallback profile |
 | `llamacpp` | profile | Yes | Full shell-style command line used to start llama.cpp for this profile, e.g. `llama-server -hf org/Model-GGUF --host localhost --port 8100 --ctx-size 32768`. There is no separate `model`, `host`, or `port` key — they're all read straight off this command line (`-hf`/`--hf-repo`/`-m`/`--model` for the model, `--host`/`--port` for where the coordinator proxies to). Leading `KEY=VALUE` tokens (e.g. `LLAMA_CACHE=/models llama-server ...`) are recognized and set as environment variables on the spawned process, and a leading `~`/`~/...` in any argument or value (e.g. `--slot-save-path ~/.orangu/llama-slots`) is expanded to the home directory — both are shell conveniences this command line would otherwise lose, since it's run directly rather than through a real shell |
 | `api_key` | profile | No | Sent as `Authorization: Bearer <key>` on the coordinator's own requests to this profile's llama.cpp, if `llamacpp` starts it with `--api-key` |
@@ -153,7 +154,9 @@ specialized model.
   `orangu.conf` enough headroom for a full cold load, not just a quick
   health check — otherwise `/search` may report itself unavailable simply
   because the very first detection attempt gave up too early.
-- On shutdown (`Ctrl+C`), the coordinator stops whatever `llama-server`
+- **Dynamic Hot-Reloading**: The coordinator watches `orangu-coordinator.conf` and hot-reloads changes automatically (polled every ~5 seconds) without needing a restart.
+- **Fallback Routing**: If a requested profile fails to load (e.g. out of memory), the coordinator automatically falls back to starting the `all`-role profile rather than failing the request entirely.
+- On shutdown (`Ctrl+C` or the internal `GET /v1/coordinator/shutdown` API), the coordinator gracefully stops whatever `llama-server`
   process is currently active — or still starting up — so nothing is left
   running in the background.
 

--- a/src/bin/orangu-coordinator/config.rs
+++ b/src/bin/orangu-coordinator/config.rs
@@ -40,6 +40,11 @@ pub struct CoordinatorConfiguration {
     pub startup_timeout_seconds: u64,
     /// Request/response body size cap in bytes.
     pub max_body_bytes: usize,
+    /// How long to wait before unloading an idle model. Defaults to None (disabled).
+    pub idle_timeout_seconds: Option<u64>,
+    /// Shared secret required to use `GET /v1/coordinator/shutdown`. When
+    /// absent the endpoint is disabled entirely.
+    pub shutdown_token: Option<String>,
     pub llms: HashMap<String, CoordinatorLlmEntry>,
     /// Name of the section whose `role` is `all`; used whenever a request's
     /// `model` field is absent or matches no configured entry.
@@ -231,6 +236,19 @@ pub fn load_coordinator_configuration(path: &Path) -> Result<CoordinatorConfigur
         None => default_max_body_bytes(),
     };
 
+    let idle_timeout_seconds =
+        match client.get("idle_timeout") {
+            Some(value) => Some(value.trim().parse::<u64>().map_err(|err| {
+                anyhow!("invalid value for [{CLIENT_SECTION}].idle_timeout: {err}")
+            })?),
+            None => None,
+        };
+
+    let shutdown_token = client
+        .get("shutdown_token")
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
     if sections.is_empty() {
         return Err(anyhow!("At least one named LLM profile must be defined"));
     }
@@ -256,6 +274,8 @@ pub fn load_coordinator_configuration(path: &Path) -> Result<CoordinatorConfigur
         port,
         startup_timeout_seconds,
         max_body_bytes,
+        idle_timeout_seconds,
+        shutdown_token,
         llms,
         default_entry,
     })

--- a/src/bin/orangu-coordinator/init.rs
+++ b/src/bin/orangu-coordinator/init.rs
@@ -40,6 +40,8 @@ pub async fn run_init() -> Result<()> {
     let port = prompt_number::<u16>("port", default_port())?;
     let startup_timeout = prompt_number::<u64>("startup_timeout", default_startup_timeout())?;
     let max_body_bytes = prompt_number::<usize>("max_body_bytes", default_max_body_bytes())?;
+    let idle_timeout = prompt_optional_number::<u64>("idle_timeout")?;
+    let shutdown_token = prompt_optional_string("shutdown_token")?;
 
     let mut roles = vec![("all".to_string(), prompt_required_llamacpp("all")?)];
     for role in OPTIONAL_ROLES {
@@ -51,12 +53,18 @@ pub async fn run_init() -> Result<()> {
     // `[orangu-coordinator]` values are always written, even when left at
     // their default, so the generated file documents every mandatory
     // property explicitly.
-    let client = [
+    let mut client = vec![
         format!("host = {host}"),
         format!("port = {port}"),
         format!("startup_timeout = {startup_timeout}"),
         format!("max_body_bytes = {max_body_bytes}"),
     ];
+    if let Some(t) = idle_timeout {
+        client.push(format!("idle_timeout = {t}"));
+    }
+    if let Some(tok) = shutdown_token {
+        client.push(format!("shutdown_token = {tok}"));
+    }
 
     let mut contents = format!("[orangu-coordinator]\n{}\n", client.join("\n"));
     for (role, llamacpp) in &roles {
@@ -170,6 +178,34 @@ where
             Ok(parsed) => return Ok(parsed),
             Err(_) => println!("'{value}' is not a valid number."),
         }
+    }
+}
+
+/// Prompt for an optional value that must parse as `T` (e.g. a `u64`),
+/// re-prompting on anything that does not. An empty entry returns `None`.
+fn prompt_optional_number<T>(label: &str) -> Result<Option<T>>
+where
+    T: std::str::FromStr + std::fmt::Display,
+{
+    loop {
+        let value = prompt(&format!("{label} [none]: "))?;
+        if value.is_empty() {
+            return Ok(None);
+        }
+        match value.parse::<T>() {
+            Ok(parsed) => return Ok(Some(parsed)),
+            Err(_) => println!("'{value}' is not a valid number."),
+        }
+    }
+}
+
+/// Prompt for an optional string value. An empty entry returns `None`.
+fn prompt_optional_string(label: &str) -> Result<Option<String>> {
+    let value = prompt(&format!("{label} [none]: "))?;
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(value))
     }
 }
 

--- a/src/bin/orangu-coordinator/main.rs
+++ b/src/bin/orangu-coordinator/main.rs
@@ -138,7 +138,7 @@ fn main() -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    match build_runtime().block_on(run(args, config, std_listener)) {
+    match build_runtime().block_on(run(args, config, std_listener, config_path)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
             eprintln!("error: {err:#}");
@@ -175,6 +175,7 @@ async fn run(
     args: Args,
     config: CoordinatorConfiguration,
     std_listener: std::net::TcpListener,
+    config_path: PathBuf,
 ) -> Result<()> {
     let _terminal_title_guard = (!args.daemon).then(|| TerminalTitleGuard::new(TERMINAL_TITLE));
     let listen = config.listen_addr();
@@ -187,6 +188,7 @@ async fn run(
         .collect();
     profile_summary.sort();
 
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::channel::<()>(1);
     let coordinator = Arc::new(Coordinator::new(config, args.quiet)?);
 
     // Eagerly activate the `all`-role profile so the default model is
@@ -211,6 +213,45 @@ async fn run(
         }
     });
 
+    let background_coordinator = coordinator.clone();
+    let config_path_clone = config_path.clone();
+    tokio::spawn(async move {
+        let mut last_modified = tokio::fs::metadata(&config_path_clone)
+            .await
+            .ok()
+            .and_then(|m| m.modified().ok());
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+            // Check config
+            if let Ok(metadata) = tokio::fs::metadata(&config_path_clone).await
+                && let Ok(modified) = metadata.modified()
+                && Some(modified) != last_modified
+            {
+                last_modified = Some(modified);
+                if let Ok(new_config) = load_coordinator_configuration(&config_path_clone) {
+                    if !quiet {
+                        println!(
+                            "reloaded configuration from {}",
+                            config_path_clone.display()
+                        );
+                    }
+                    background_coordinator.reload_config(new_config);
+                    // Reconcile: if the active profile was removed or its
+                    // command changed, stop the now-stale process.
+                    background_coordinator.stop_if_stale().await;
+                } else if !quiet {
+                    eprintln!("warning: failed to reload configuration; keeping previous state");
+                }
+            }
+
+            // Check idle
+            if let Some(timeout_secs) = background_coordinator.idle_timeout() {
+                background_coordinator.unload_if_idle(timeout_secs).await;
+            }
+        }
+    });
+
     let app = Router::new()
         .route(
             "/v1/coordinator",
@@ -219,6 +260,30 @@ async fn run(
         .route(
             "/v1/coordinator/activate",
             axum::routing::post(proxy::activate),
+        )
+        .route(
+            "/v1/coordinator/shutdown",
+            axum::routing::get({
+                let tx = shutdown_tx.clone();
+                let shutdown_coordinator = coordinator.clone();
+                move |connect_info: axum::extract::ConnectInfo<std::net::SocketAddr>,
+                      query: axum::extract::Query<std::collections::HashMap<String, String>>| async move {
+                    // Defense-in-depth: reject non-loopback even with a valid token.
+                    if !connect_info.0.ip().is_loopback() {
+                        return (axum::http::StatusCode::FORBIDDEN, "shutdown is only available from localhost\n");
+                    }
+                    // Require a matching shutdown_token from config.
+                    let Some(expected) = shutdown_coordinator.shutdown_token() else {
+                        return (axum::http::StatusCode::NOT_FOUND, "shutdown endpoint is disabled; set shutdown_token in config to enable\n");
+                    };
+                    let provided = query.get("token").map(|s| s.as_str()).unwrap_or("");
+                    if provided != expected {
+                        return (axum::http::StatusCode::FORBIDDEN, "invalid shutdown token\n");
+                    }
+                    let _ = tx.send(()).await;
+                    (axum::http::StatusCode::OK, "shutting down...\n")
+                }
+            }),
         )
         .fallback(proxy::proxy)
         .layer(DefaultBodyLimit::max(max_body_bytes))
@@ -236,10 +301,16 @@ async fn run(
 
     let shutdown_coordinator = coordinator.clone();
     let result = tokio::select! {
-        result = axum::serve(listener, app) => result.context("server error"),
+        result = axum::serve(listener, app.into_make_service_with_connect_info::<std::net::SocketAddr>()) => result.context("server error"),
         _ = tokio::signal::ctrl_c() => {
             if !args.quiet {
                 println!("shutting down...");
+            }
+            Ok(())
+        },
+        _ = shutdown_rx.recv() => {
+            if !args.quiet {
+                println!("shutting down via API...");
             }
             Ok(())
         }

--- a/src/bin/orangu-coordinator/process.rs
+++ b/src/bin/orangu-coordinator/process.rs
@@ -19,7 +19,15 @@
 
 use crate::config::{CoordinatorConfiguration, CoordinatorLlmEntry};
 use anyhow::{Context, Result, anyhow};
-use std::{collections::HashMap, collections::VecDeque, process::Stdio, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    collections::VecDeque,
+    process::Stdio,
+    sync::Arc,
+    sync::Mutex as StdMutex,
+    sync::atomic::{AtomicU32, Ordering},
+    time::Duration,
+};
 use tokio::{
     io::{AsyncBufReadExt, AsyncRead, BufReader},
     process::Command,
@@ -31,6 +39,9 @@ use tokio::{
 struct ActiveProcess {
     entry_name: String,
     child: tokio::process::Child,
+    /// The `llamacpp` command that was used to start this process, so
+    /// hot-reload can detect when a profile's command changed.
+    llamacpp_at_start: String,
     /// Kept for the process's whole lifetime (not just while starting) so a
     /// crash discovered later — e.g. while it was actively serving a
     /// request — can still be reported with its own diagnostic output
@@ -48,7 +59,8 @@ const OUTPUT_TAIL_LINES: usize = 20;
 type OutputTail = Arc<Mutex<VecDeque<String>>>;
 
 pub struct Coordinator {
-    config: CoordinatorConfiguration,
+    /// RwLock to allow hot-reloading config.
+    config: std::sync::RwLock<CoordinatorConfiguration>,
     http_client: reqwest::Client,
     active: Mutex<Option<ActiveProcess>>,
     /// PID of whatever llama.cpp process is currently starting or active, if
@@ -59,11 +71,13 @@ pub struct Coordinator {
     /// `shutdown` must not have to wait on that same lock just to kill a
     /// still-starting process, so this is tracked separately and only ever
     /// locked briefly.
-    current_pid: Mutex<Option<u32>>,
+    current_pid: AtomicU32,
     /// Suppresses echoing a starting/active process's stdout/stderr to the
     /// coordinator's own output, mirroring `--quiet`. The lines are still
     /// captured into each process's tail regardless, for error reporting.
     quiet: bool,
+    /// When the coordinator was last accessed by a request (for idle timeout).
+    last_accessed: StdMutex<Instant>,
 }
 
 /// Per-attempt timeout for the `/v1/models` health-check probe only — kept
@@ -88,11 +102,12 @@ impl Coordinator {
             .build()
             .context("failed to build HTTP client")?;
         Ok(Self {
-            config,
+            config: std::sync::RwLock::new(config),
             http_client,
             active: Mutex::new(None),
-            current_pid: Mutex::new(None),
+            current_pid: AtomicU32::new(0),
             quiet,
+            last_accessed: StdMutex::new(Instant::now()),
         })
     }
 
@@ -104,8 +119,13 @@ impl Coordinator {
 
     /// The model each conventional role resolves to, for `GET
     /// /v1/coordinator` — see [`CoordinatorConfiguration::models_by_role`].
-    pub fn models_by_role(&self) -> Vec<(&str, &str)> {
-        self.config.models_by_role()
+    pub fn models_by_role(&self) -> Vec<(String, String)> {
+        let config = self.config.read().unwrap();
+        config
+            .models_by_role()
+            .into_iter()
+            .map(|(r, m)| (r.to_string(), m.to_string()))
+            .collect()
     }
 
     /// Matches `hint` against a real model id, then a role name — see
@@ -114,7 +134,70 @@ impl Coordinator {
     /// `all`-role fallback: an explicit activation request that names
     /// nothing configured is a caller error, not something to paper over.
     pub fn match_hint(&self, hint: &str) -> Option<CoordinatorLlmEntry> {
-        match_hint(&self.config.llms, hint).cloned()
+        let config = self.config.read().unwrap();
+        match_hint(&config.llms, hint).cloned()
+    }
+
+    pub fn idle_timeout(&self) -> Option<u64> {
+        self.config.read().unwrap().idle_timeout_seconds
+    }
+
+    pub fn shutdown_token(&self) -> Option<String> {
+        self.config.read().unwrap().shutdown_token.clone()
+    }
+
+    pub fn default_entry(&self) -> CoordinatorLlmEntry {
+        let config = self.config.read().unwrap();
+        config.llms[&config.default_entry].clone()
+    }
+
+    pub fn reload_config(&self, new_config: CoordinatorConfiguration) {
+        *self.config.write().unwrap() = new_config;
+    }
+
+    /// After a config reload, stop the active process if its profile was
+    /// removed or its `llamacpp` command changed — otherwise it would keep
+    /// running with stale settings indefinitely.
+    pub async fn stop_if_stale(&self) {
+        // Snapshot the active identity without holding the async mutex while
+        // reading the (blocking) config lock.
+        let (entry_name, llamacpp_at_start) = {
+            let guard = self.active.lock().await;
+            let Some(active) = guard.as_ref() else {
+                return;
+            };
+            (active.entry_name.clone(), active.llamacpp_at_start.clone())
+        };
+
+        let should_stop = {
+            let config = self.config.read().unwrap();
+            match config.llms.get(&entry_name) {
+                None => true, // profile was removed
+                Some(entry) => entry.llamacpp != llamacpp_at_start,
+            }
+        };
+
+        if !should_stop {
+            return;
+        }
+
+        // Re-lock and verify the active process is still the same one we
+        // snapshotted — a concurrent request could have swapped it.
+        let mut guard = self.active.lock().await;
+        if let Some(active) = guard.as_ref()
+            && active.entry_name == entry_name
+            && active.llamacpp_at_start == llamacpp_at_start
+        {
+            let active = guard.take().expect("checked above");
+            if !self.quiet {
+                println!(
+                    "stopping '{}' — profile was removed or changed in reloaded config",
+                    active.entry_name
+                );
+            }
+            self.current_pid.store(0, Ordering::Relaxed);
+            Self::stop(active).await;
+        }
     }
 
     /// Picks the configured entry a request should be routed to, trying each
@@ -145,20 +228,23 @@ impl Coordinator {
         &self,
         model_hint: Option<&str>,
         implied_role: Option<&str>,
-    ) -> &CoordinatorLlmEntry {
+    ) -> CoordinatorLlmEntry {
+        self.touch_last_accessed();
         let active_entry_name = self
             .active
             .lock()
             .await
             .as_ref()
             .map(|active| active.entry_name.clone());
+        let config = self.config.read().unwrap();
         select_entry(
-            &self.config.llms,
-            &self.config.default_entry,
+            &config.llms,
+            &config.default_entry,
             model_hint,
             implied_role,
             active_entry_name.as_deref(),
         )
+        .clone()
     }
 
     /// Ensures `entry`'s llama.cpp is the active process, starting it (and
@@ -187,13 +273,14 @@ impl Coordinator {
             // Clear `current_pid` before reaping: once `stop` returns, that
             // pid is gone and the OS is free to recycle it, so it must not
             // linger as a stale value a concurrent `shutdown` could kill.
-            *self.current_pid.lock().await = None;
+            self.current_pid.store(0, Ordering::Relaxed);
             Self::stop(guard.take().expect("checked above")).await;
         }
 
         let (child, tail) = self.start(entry).await?;
         *guard = Some(ActiveProcess {
             entry_name: entry.name.clone(),
+            llamacpp_at_start: entry.llamacpp.clone(),
             child,
             tail,
         });
@@ -207,20 +294,63 @@ impl Coordinator {
     /// would miss, since `active` isn't populated until the health check
     /// succeeds.
     pub async fn shutdown(&self) {
-        if let Some(pid) = self.current_pid.lock().await.take() {
-            kill_pid(pid);
-        }
+        self.current_pid.store(0, Ordering::Relaxed);
         let mut guard = self.active.lock().await;
-        if let Some(mut active) = guard.take() {
-            // Already signalled above (if it was this same process); this
-            // just reaps it so it doesn't linger as a zombie.
-            let _ = active.child.wait().await;
+        if let Some(active) = guard.take() {
+            Self::stop(active).await;
+        }
+        // If no active process exists but a stale PID was recorded (still
+        // mid-startup), we intentionally do NOT signal it here: the startup
+        // code path still holds the Child handle, and `kill_on_drop(true)`
+        // ensures the process is cleaned up when that handle is dropped.
+        // Signalling a bare PID risks hitting an unrelated process if the
+        // OS has already recycled it.
+    }
+
+    pub fn touch_last_accessed(&self) {
+        *self.last_accessed.lock().unwrap() = Instant::now();
+    }
+
+    pub async fn unload_if_idle(&self, timeout_secs: u64) {
+        let last_accessed = *self.last_accessed.lock().unwrap();
+        if last_accessed.elapsed().as_secs() >= timeout_secs {
+            let mut guard = self.active.lock().await;
+            let last_accessed = *self.last_accessed.lock().unwrap();
+            if last_accessed.elapsed().as_secs() >= timeout_secs
+                && let Some(active) = guard.take()
+            {
+                if !self.quiet {
+                    println!(
+                        "unloading active profile '{}' due to idle timeout",
+                        active.entry_name
+                    );
+                }
+                self.current_pid.store(0, Ordering::Relaxed);
+                Self::stop(active).await;
+            }
         }
     }
 
     async fn stop(mut active: ActiveProcess) {
-        let _ = active.child.start_kill();
-        let _ = active.child.wait().await;
+        #[cfg(unix)]
+        {
+            if let Some(pid) = active.child.id() {
+                kill_pid(pid);
+            }
+            // Wait up to 5 seconds for graceful shutdown
+            if tokio::time::timeout(Duration::from_secs(5), active.child.wait())
+                .await
+                .is_err()
+            {
+                let _ = active.child.start_kill();
+                let _ = active.child.wait().await;
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = active.child.start_kill();
+            let _ = active.child.wait().await;
+        }
     }
 
     async fn start(
@@ -241,6 +371,7 @@ impl Coordinator {
             .stdin(std::process::Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .kill_on_drop(true)
             .spawn()
             .with_context(|| {
                 format!(
@@ -252,7 +383,8 @@ impl Coordinator {
         // Record the PID *before* the (possibly long) health-check wait
         // below, so a concurrent `shutdown` can always kill this process,
         // no matter how long it takes to become ready.
-        *self.current_pid.lock().await = child.id();
+        self.current_pid
+            .store(child.id().unwrap_or(0), Ordering::Relaxed);
 
         let tail: OutputTail = Arc::new(Mutex::new(VecDeque::new()));
         if let Some(stdout) = child.stdout.take() {
@@ -265,7 +397,7 @@ impl Coordinator {
         if let Err(err) = self.wait_until_healthy(entry, &mut child, &tail).await {
             let _ = child.start_kill();
             let _ = child.wait().await;
-            *self.current_pid.lock().await = None;
+            self.current_pid.store(0, Ordering::Relaxed);
             return Err(err);
         }
 
@@ -278,7 +410,8 @@ impl Coordinator {
         child: &mut tokio::process::Child,
         tail: &OutputTail,
     ) -> Result<()> {
-        let deadline = Instant::now() + Duration::from_secs(self.config.startup_timeout_seconds);
+        let startup_timeout = self.config.read().unwrap().startup_timeout_seconds;
+        let deadline = Instant::now() + Duration::from_secs(startup_timeout);
         let probe_url = format!("{}/v1/models", entry.origin());
 
         loop {
@@ -306,7 +439,7 @@ impl Coordinator {
             if Instant::now() >= deadline {
                 return Err(anyhow!(
                     "timed out after {}s waiting for llama.cpp ('{}') to become ready at {}{}",
-                    self.config.startup_timeout_seconds,
+                    startup_timeout,
                     entry.name,
                     probe_url,
                     format_output_tail(tail).await
@@ -506,7 +639,7 @@ fn match_hint<'a>(
 #[cfg(unix)]
 fn kill_pid(pid: u32) {
     unsafe {
-        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+        libc::kill(pid as libc::pid_t, libc::SIGINT);
     }
 }
 
@@ -904,7 +1037,8 @@ mod tests {
         // Let the health-check loop actually start (and record the pid)
         // before shutting down.
         let pid = loop {
-            if let Some(pid) = *coordinator.current_pid.lock().await {
+            let pid = coordinator.current_pid.load(Ordering::Relaxed);
+            if pid != 0 {
                 break pid;
             }
             tokio::time::sleep(Duration::from_millis(20)).await;

--- a/src/bin/orangu-coordinator/proxy.rs
+++ b/src/bin/orangu-coordinator/proxy.rs
@@ -144,20 +144,36 @@ pub async fn proxy(
     let implied_role = implied_role_for_path(uri.path());
     let entry = coordinator
         .resolve_entry(model_hint.as_deref(), implied_role)
-        .await
-        .clone();
+        .await;
 
-    let origin = match coordinator.ensure_active(&entry).await {
-        Ok(origin) => origin,
+    let (origin, effective_entry) = match coordinator.ensure_active(&entry).await {
+        Ok(origin) => (origin, entry),
         Err(err) => {
-            return (
-                StatusCode::BAD_GATEWAY,
-                format!(
-                    "orangu-coordinator: failed to start '{}': {err:#}",
-                    entry.name
-                ),
-            )
-                .into_response();
+            let default_entry = coordinator.default_entry();
+            if entry.name != default_entry.name {
+                eprintln!(
+                    "warning: failed to start '{}': {err:#}; falling back to '{}'",
+                    entry.name, default_entry.name
+                );
+                match coordinator.ensure_active(&default_entry).await {
+                    Ok(origin) => (origin, default_entry),
+                    Err(fallback_err) => {
+                        return (
+                            StatusCode::BAD_GATEWAY,
+                            format!("orangu-coordinator: failed to start both '{}' and fallback '{}': {fallback_err:#}", entry.name, default_entry.name),
+                        ).into_response();
+                    }
+                }
+            } else {
+                return (
+                    StatusCode::BAD_GATEWAY,
+                    format!(
+                        "orangu-coordinator: failed to start default profile '{}': {err:#}",
+                        entry.name
+                    ),
+                )
+                    .into_response();
+            }
         }
     };
 
@@ -174,7 +190,7 @@ pub async fn proxy(
         }
         request = request.header(name, value);
     }
-    if let Some(api_key) = &entry.api_key {
+    if let Some(api_key) = &effective_entry.api_key {
         request = request.bearer_auth(api_key);
     }
 


### PR DESCRIPTION
## Changes
- **Auto-Unload:** Added an optional `idle_timeout` config to automatically unload inactive models and free VRAM.
- **Config Hot-Reloading:** The proxy now periodically polls `orangu-coordinator.conf` and applies routing changes instantly without a restart.
- **Fallback Routing:** Automatically routes to the default `all` profile if a requested model fails to load (e.g. out of memory).
- **Graceful Shutdown API:** Added `GET /v1/coordinator/shutdown` (secured via loopback check and optional `shutdown_token`) to allow clean session termination.
- **Reliability Fixes:** 
  - Orphaned processes are now cleaned up via `.kill_on_drop(true)`.
  - Replaced `SIGKILL` with `SIGINT` to allow `llama-server` to save its KV cache.
  - Fixed multiple edge cases around stale PID kills, fallback credentials, and hot-reload process reconciliation.
