### PR TITLE
[#173] orangu-gguf: Windows fixes for download symlinks and GPU listing

### DIFF
--- a/src/bin/orangu-gguf/download.rs
+++ b/src/bin/orangu-gguf/download.rs
@@ -592,6 +592,14 @@ fn link_or_copy(blob: &Path, link: &Path, oid: &str, file_path: &str) -> Result<
     // then two more reach the repo root, then descend into `blobs/<oid>`.
     let ups = "../".repeat(file_path.matches('/').count() + 2);
     let target = format!("{ups}blobs/{oid}");
+    // Windows only resolves symlink targets with backslash separators: a
+    // forward-slash target creates a link that Windows itself cannot follow
+    // (every native read fails with "the filename, directory name, or volume
+    // label syntax is incorrect"), so the model would be invisible to `list`
+    // and unreadable by llama-server, even though POSIX-emulating shells
+    // resolve it fine.
+    #[cfg(windows)]
+    let target = target.replace('/', "\\");
 
     #[cfg(unix)]
     let symlink_result = std::os::unix::fs::symlink(&target, link);

--- a/src/bin/orangu-gguf/system.rs
+++ b/src/bin/orangu-gguf/system.rs
@@ -129,8 +129,20 @@ pub fn detect_gpus(total_memory_bytes: u64) -> Vec<GpuInfo> {
     #[cfg(target_os = "macos")]
     gpus.extend(detect_macos_gpus());
 
+    // Like the Linux sysfs scan, skip the NVIDIA adapters WMI reports when
+    // `nvidia-smi` already listed them above with better data (real VRAM
+    // use, and totals beyond `AdapterRAM`'s 32-bit cap) — without this the
+    // same card shows up twice. When `nvidia-smi` isn't available (it found
+    // nothing), WMI is the only source, so its NVIDIA entries are kept.
     #[cfg(target_os = "windows")]
-    gpus.extend(detect_windows_gpus());
+    {
+        let have_nvidia_smi = !gpus.is_empty();
+        gpus.extend(
+            detect_windows_gpus()
+                .into_iter()
+                .filter(|gpu| !have_nvidia_smi || !gpu.name.to_lowercase().contains("nvidia")),
+        );
+    }
 
     apply_shared_memory_total(&mut gpus, total_memory_bytes);
     gpus
@@ -529,9 +541,17 @@ pub fn format_report(cpu: &CpuInfo, gpus: &[GpuInfo]) -> String {
         if index > 0 {
             out.push('\n');
         }
+        // Skip the vendor prefix when the device name already leads with it
+        // (nvidia-smi reports "NVIDIA GeForce ..."), so the line doesn't
+        // read "NVIDIA NVIDIA GeForce ...".
+        let redundant_vendor = gpu.vendor.is_empty()
+            || gpu
+                .name
+                .to_lowercase()
+                .starts_with(&gpu.vendor.to_lowercase());
         out.push_str(&format!(
             "  [{index}] {}{}\n",
-            if gpu.vendor.is_empty() {
+            if redundant_vendor {
                 String::new()
             } else {
                 format!("{} ", gpu.vendor)


### PR DESCRIPTION
Part of #173. Two Windows-specific bugs found while testing the initial patch on a hybrid Intel/NVIDIA laptop (i5-12450H, Intel UHD + RTX 2050), plus one cosmetic fix:

- **`download`'s snapshot symlinks were dead on Windows.** The relative target was written with forward slashes (`../../blobs/<oid>`), which Windows cannot resolve: every native read through the link fails with "the filename, directory name, or volume label syntax is incorrect", so the model `orangu-gguf` itself had just fetched was invisible to `list`/`show`/the wizard and would be unreadable by llama-server. POSIX-emulating shells (Git Bash) resolve such links fine, which hides the problem. The target now uses backslashes on Windows. Verified: after the fix, `list` finds the downloaded model and `show`/the wizard read it.

- **`system` listed every NVIDIA card twice**: once from nvidia-smi and again from `Win32_VideoController`. The WMI pass now skips NVIDIA adapters when nvidia-smi already reported them (with better data: real VRAM use, and totals beyond `AdapterRAM`'s 32-bit cap), keeping them when nvidia-smi isn't available and WMI is the only source, mirroring the Linux sysfs scan's dedupe.

- Cosmetic: the report printed `[0] NVIDIA NVIDIA GeForce RTX 2050`; the vendor prefix is now skipped when the device name already leads with it.

All 64 orangu-gguf unit tests pass; clippy clean.