### PR TITLE
[#173] orangu-gguf suggest: rename the Shared table to Combined

### DIFF
--- a/doc/GGUF.md
+++ b/doc/GGUF.md
@@ -243,7 +243,7 @@ Suggested model size (Dedicated)
   128K     -                  -                    -
   256K     -                  -                    -
 
-Suggested model size (Shared)
+Suggested model size (Combined)
   Estimated budget : 66.17 GiB
 
   Context  Suggestion (Q2_K)  Suggestion (Q4_K_M)  Suggestion (Q8_0)
@@ -271,11 +271,15 @@ Two such tables are printed, sized against two different budgets:
 - **Dedicated**: the sum of every **dedicated** GPU's VRAM alone (multiple
   dedicated cards add up, matching `-sm layer`'s multi-GPU tensor split) —
   everything fits in real VRAM, no spillover.
-- **Shared**: the sum of *every* GPU's own reported total, dedicated and
+- **Combined**: the sum of *every* GPU's own reported total, dedicated and
   shared alike (a shared/integrated GPU's is already the system's total RAM,
   per the note above) — the more permissive figure, representing every
   device `--fit on` could spread layers across at once. Falls back to the
-  CPU's own total RAM when there's no GPU detected at all.
+  CPU's own total RAM when there's no GPU detected at all. Inherently
+  optimistic: the shared part of the pool is the same RAM the OS and
+  everything else on the machine live in, so treat it as a hardware
+  ceiling, not a promise — with dedicated VRAM added on top it can even
+  exceed the machine's total RAM.
 
 The memory-estimation formula mirrors [Sam McLeod's GGUF VRAM
 Estimator](https://smcleod.net/vram-estimator/) (read directly from its

--- a/doc/manual/en/45-gguf.md
+++ b/doc/manual/en/45-gguf.md
@@ -214,7 +214,7 @@ Suggested model size (Dedicated)
   128K     -                  -                    -
   256K     -                  -                    -
 
-Suggested model size (Shared)
+Suggested model size (Combined)
   Estimated budget : 66.17 GiB
 
   Context  Suggestion (Q2_K)  Suggestion (Q4_K_M)  Suggestion (Q8_0)
@@ -235,11 +235,15 @@ model (in parameters) is likely to run comfortably — as a table, one row per
 context length (1K to 256K tokens) and one column per quantization (`Q2_K`,
 `Q4_K_M` — this project's own default — and `Q8_0`), not a specific model
 recommendation yet, just a size class to aim `download` at once you know
-what to look for. Two such tables are printed: one sized against dedicated
-GPU VRAM alone (everything fits in real VRAM, no spillover), and one against
-every GPU's memory combined — dedicated and shared alike, a
-shared/integrated GPU's already being the system's total RAM — falling back
-to the CPU's own total RAM when there's no GPU at all.
+what to look for. Two such tables are printed: **Dedicated**, sized against
+dedicated GPU VRAM alone (everything fits in real VRAM, no spillover), and
+**Combined**, against every GPU's memory combined — dedicated and shared
+alike, a shared/integrated GPU's already being the system's total RAM —
+falling back to the CPU's own total RAM when there's no GPU at all. The
+combined figure is inherently optimistic: the shared part of the pool is
+the same RAM the OS and everything else on the machine live in, so treat it
+as a hardware ceiling rather than a promise — with dedicated VRAM added on
+top it can even exceed the machine's total RAM.
 
 The memory-estimation formula mirrors [Sam McLeod's GGUF VRAM
 Estimator](https://smcleod.net/vram-estimator/) and the general shape of

--- a/doc/manual/en/77-gguf.md
+++ b/doc/manual/en/77-gguf.md
@@ -414,10 +414,15 @@ Since `suggest` runs before any model is chosen, there's no real GGUF file
 to read `hidden_size`/`layers` from (unlike `roles.rs`'s
 `architecture_metadata_u64`, which reads them from an actual model).
 `estimate_hidden_dims` instead estimates both from the parameter count
-alone, via the standard transformer parameter-count approximation params ≈
-12 × layers × hidden_size² (solved for `hidden_size = sqrt(params / 12)`,
-then `layers` from that) — the exact same fallback smcleod's own calculator
-uses when it has no real GGUF metadata to read either.
+alone. The standard transformer parameter-count approximation (params ≈ 12
+× layers × hidden_size²) is one equation with two unknowns, so the split is
+underdetermined; it's resolved by putting everything into the hidden size
+(`hidden_size = sqrt(params / 12)`), which makes `layers` work out to
+exactly 1 by construction. The KV-cache estimate built on it therefore
+scales as context × √params — which tracks modern GQA-era models well
+(their per-layer KV width shrinks as depth grows, so total KV grows
+sublinearly in parameters), and matches the fallback smcleod's own
+calculator uses when it has no real GGUF metadata to read either.
 
 `DEFAULT_BITS_PER_WEIGHT` (4.83, Q4_K_M) and `KV_CACHE_BITS` (8, Q8_0) match
 this project's own established defaults (`download.rs`'s
@@ -444,7 +449,7 @@ even the smallest rung (1B) doesn't (rendered as `-`).
 
 **Two budgets, two tables.** `format_suggestion` computes two separate
 budgets and prints a labeled `push_suggestion_block` for each, `"Suggested
-model size (Dedicated)"` and `"Suggested model size (Shared)"`. Both sum each
+model size (Dedicated)"` and `"Suggested model size (Combined)"`. Both sum each
 eligible GPU's own `vram_total_bytes` — deliberately *not* reduced by
 `vram_used_bytes`, since `suggest` estimates the hardware's own capability
 (this file's module doc — "likely to run comfortably on this machine",

--- a/src/bin/orangu-gguf/suggest.rs
+++ b/src/bin/orangu-gguf/suggest.rs
@@ -80,9 +80,17 @@ const PARAM_LADDER_BILLIONS: &[f64] = &[
     12.0, 9.0, 8.0, 7.0, 4.0, 3.0, 2.0, 1.0,
 ];
 
-/// Estimates hidden size and layer count from a parameter count alone, via
-/// the standard transformer-parameter approximation params ≈ 12 × layers ×
-/// hidden_size².
+/// Estimates hidden size and layer count from a parameter count alone.
+///
+/// The standard transformer approximation (params ≈ 12 × layers ×
+/// hidden_size²) is one equation with two unknowns, so the split is
+/// underdetermined: this resolves it by putting everything into the hidden
+/// size (`hidden = √(params ÷ 12)`), which makes `layers` work out to
+/// exactly 1 — by construction, not by accident. The KV-cache estimate
+/// built on it therefore scales as context × √params, which tracks modern
+/// GQA-era models well (their per-layer KV width shrinks as depth grows,
+/// so total KV grows sublinearly in parameters), and matches what smcleod's
+/// own calculator falls back to without real GGUF metadata to read.
 fn estimate_hidden_dims(params_billion: f64) -> (f64, f64) {
     let params = params_billion * 1e9;
     let hidden_size = (params / 12.0).sqrt();
@@ -198,7 +206,11 @@ fn dedicated_vram_budget_bytes(gpus: &[GpuInfo]) -> u64 {
 /// budget, representing every device `--fit on` could spread layers across
 /// at once. Falls back to the CPU's own total RAM when that sum is `0` (no
 /// GPU detected at all). Like [`dedicated_vram_budget_bytes`], deliberately
-/// not reduced by currently-used memory — see its doc for why.
+/// not reduced by currently-used memory — see its doc for why. A combined
+/// figure is inherently optimistic: the shared part of the pool is the same
+/// RAM the OS and everything else on the machine live in, so it's a
+/// hardware ceiling, not a promise — it can even exceed the machine's total
+/// RAM when dedicated VRAM is added on top.
 fn combined_gpu_budget_bytes(cpu: &CpuInfo, gpus: &[GpuInfo]) -> u64 {
     let total: u64 = gpus
         .iter()
@@ -278,7 +290,7 @@ pub fn format_suggestion(cpu: &CpuInfo, gpus: &[GpuInfo]) -> String {
     );
     push_suggestion_block(
         &mut out,
-        "Suggested model size (Shared)",
+        "Suggested model size (Combined)",
         combined_gpu_budget_bytes(cpu, gpus),
     );
 
@@ -526,7 +538,7 @@ mod tests {
         assert!(report.contains("CPU"));
         assert!(report.contains("GPU"));
         assert!(report.contains("Suggested model size (Dedicated)"));
-        assert!(report.contains("Suggested model size (Shared)"));
+        assert!(report.contains("Suggested model size (Combined)"));
         assert!(report.contains("Suggestion (Q2_K)"));
         assert!(report.contains("Suggestion (Q4_K_M)"));
         assert!(report.contains("Suggestion (Q8_0)"));
@@ -536,7 +548,7 @@ mod tests {
         let dedicated_section = report
             .split("(Dedicated)")
             .nth(1)
-            .and_then(|rest| rest.split("(Shared)").next())
+            .and_then(|rest| rest.split("(Combined)").next())
             .unwrap();
         assert!(dedicated_section.contains("4.00 GiB"));
     }


### PR DESCRIPTION
Part of #173, as discussed by mail.

- The second suggestion table is renamed from `Suggested model size (Shared)` to `Suggested model size (Combined)`: it sums every eligible GPU's total, dedicated and shared alike, so on a machine with both (my laptop: 4 GiB RTX 2050 + shared Intel UHD) it prints a budget larger than system RAM, which under a "(Shared)" heading reads like a bug at first glance.
- The docs (GGUF.md, manual chapters 45 and 77) follow the rename and now note the combined figure is inherently optimistic: the shared part of the pool is the same RAM the OS and everything else on the machine live in, so it's a hardware ceiling rather than a promise.
- `estimate_hidden_dims`'s documentation (and the matching passage in chapter 77) now says what the function really does: the params = 12 x layers x hidden^2 approximation is one equation with two unknowns, resolved by putting everything into the hidden size, so `layers` always works out to exactly 1 by construction; the KV estimate built on it scales as context x sqrt(params), which tracks GQA-era models well. The old comment read like it computed a real layer count.

No behavioral changes beyond the printed label. All 81 orangu-gguf tests pass (labels updated); clippy clean; verified the live output on my machine shows `(Combined)` with the same numbers as before.