### PR TITLE
[#191] Surface session save errors in-app instead of silencing them

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Tejas Singh Bhati <tejassinghbhati077@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
 Nishant raj Jha <nishantrajx924@gmail.com>
+Adesh Deshmukh <adeshkd123@gmail.com>

--- a/doc/manual/en/97-acknowledgement.md
+++ b/doc/manual/en/97-acknowledgement.md
@@ -12,6 +12,7 @@ Mahmoud Hamdy (TutTrue) <mahmoud.hamdy5113@gmail.com>
 Tejas Singh Bhati <tejassinghbhati077@gmail.com>
 Shashank Singh <shashanksgh3@gmail.com>
 Nishant raj Jha <nishantrajx924@gmail.com>
+Adesh Deshmukh <adeshkd123@gmail.com>
 ```
 
 ## Committers

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -1320,11 +1320,24 @@ async fn run() -> Result<()> {
                     pending_tab_action = Some(TabAction::SwitchTo(index));
                     continue;
                 }
-                let _ = save_session_messages(&session_messages_path, session.messages());
-                let _ = update_session_metadata_branch(
+                if let Err(err) = save_session_messages(&session_messages_path, session.messages())
+                {
+                    output_state.push_text(&format!("Failed to save session: {err:#}"));
+                    if config.feedback {
+                        output_state.push_text(FEEDBACK_ERR);
+                    }
+                    output_state.reset_scroll();
+                }
+                if let Err(err) = update_session_metadata_branch(
                     &session_metadata_path,
                     workspace_branch_name(tools.workspace()).as_deref(),
-                );
+                ) {
+                    output_state.push_text(&format!("Failed to save session metadata: {err:#}"));
+                    if config.feedback {
+                        output_state.push_text(FEEDBACK_ERR);
+                    }
+                    output_state.reset_scroll();
+                }
                 match WorkspaceTab::open(
                     dir,
                     None,
@@ -1365,11 +1378,26 @@ async fn run() -> Result<()> {
                 if let Some(index) = ring.position_of(&workspace, &dir) {
                     pending_tab_action = Some(TabAction::SwitchTo(index));
                 } else {
-                    let _ = save_session_messages(&session_messages_path, session.messages());
-                    let _ = update_session_metadata_branch(
+                    if let Err(err) =
+                        save_session_messages(&session_messages_path, session.messages())
+                    {
+                        output_state.push_text(&format!("Failed to save session: {err:#}"));
+                        if config.feedback {
+                            output_state.push_text(FEEDBACK_ERR);
+                        }
+                        output_state.reset_scroll();
+                    }
+                    if let Err(err) = update_session_metadata_branch(
                         &session_metadata_path,
                         workspace_branch_name(tools.workspace()).as_deref(),
-                    );
+                    ) {
+                        output_state
+                            .push_text(&format!("Failed to save session metadata: {err:#}"));
+                        if config.feedback {
+                            output_state.push_text(FEEDBACK_ERR);
+                        }
+                        output_state.reset_scroll();
+                    }
                     match WorkspaceTab::open(
                         dir,
                         None,


### PR DESCRIPTION
Closes #191

Noticed this while tracing through the tab-switch flow in main.rs — save_session_messages() and update_session_metadata_branch() both return Result<()> but the callers in OpenWorkspaceTab and ChangeWorkspace just throw the value away with let _ =. If the disk is full or the session directory is unwritable, the user loses their entire conversation history with zero indication.

Everywhere else handles this right — save_all_tabs! on quit uses ?, workspace_tab.rs:285 uses ?. These two spots were just overlooked.

Changed them both to surface the error in the TUI via push_text(), same way WorkspaceTab::open() already handles its own failures a few lines below. If saving fails the user sees it and can retry or /copy their work before switching — nothing is lost since the session is still in memory.

save_all_tabs! stays as-is with ? since we're exiting anyway.

Also added myself to AUTHORS.