### PR TITLE
[#198] propagate git_commit_count parse failures instead of returning 0

### DIFF
--- a/src/bin/orangu/git/forge.rs
+++ b/src/bin/orangu/git/forge.rs
@@ -836,18 +836,23 @@ pub fn create_pull_request_output(
 }
 
 pub(crate) fn git_commit_count(repo_root: &Path, range: &str) -> Result<usize> {
-    Ok(String::from_utf8_lossy(
-        &std::process::Command::new("git")
-            .arg("-C")
-            .arg(repo_root)
-            .args(["rev-list", "--count", range])
-            .output()
-            .context("failed to run git rev-list")?
-            .stdout,
-    )
-    .trim()
-    .parse()
-    .unwrap_or(0))
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["rev-list", "--count", range])
+        .output()
+        .context("failed to run git rev-list")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!(
+            "git rev-list --count failed for range '{range}': {stderr}"
+        ));
+    }
+    let count = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .context("git rev-list --count produced unexpected output")?;
+    Ok(count)
 }
 
 /// One reviewer's status on a pull/merge request. `state` is a human-readable


### PR DESCRIPTION
Propagate `git rev-list --count` failures (non-zero exit or unparseable stdout) as errors instead of silently returning 0.\n\nCloses #198