### PR TITLE
[#199] reject git_squash when working tree is dirty

### DIFF
--- a/src/bin/orangu/git/ops.rs
+++ b/src/bin/orangu/git/ops.rs
@@ -923,6 +923,14 @@ pub fn git_squash(repo_root: &Path) -> Result<String> {
 
     let base_ref = git_find_base_ref(repo_root)?;
 
+    let (dirty_count, _) = count_pending_changes(repo_root)?;
+    if dirty_count > 0 {
+        return Err(anyhow!(
+            "working tree has {dirty_count} uncommitted change(s); \
+             commit or stash them before squashing"
+        ));
+    }
+
     let merge_base_output = std::process::Command::new("git")
         .arg("-C")
         .arg(repo_root)


### PR DESCRIPTION
Add a dirty-tree check at the start of `git_squash()` to reject the operation when the working tree has uncommitted changes.

`git reset --soft` followed by `git commit -m` silently drops uncommitted work — the squash appears to succeed but the dirty changes are excluded from the resulting commit.

The existing `count_pending_changes()` helper (used by `pending_changes_summary()` and `status_output()`) already runs `git status --porcelain`. This change calls it before any destructive operation and returns a clear error if the tree is dirty.

Closes #199

## Testing Performed
- [x] `cargo build` — compiles
- [x] `cargo clippy` — no warnings
- [x] `cargo test -p orangu --lib` — all 277 passed