### PR TITLE
[#204] reject PR creation when working tree is dirty

### DIFF
--- a/src/bin/orangu/git/forge.rs
+++ b/src/bin/orangu/git/forge.rs
@@ -808,6 +808,13 @@ pub fn create_pull_request_output(
             current
         ));
     }
+    let (dirty_count, _) = count_pending_changes(&repo_root)?;
+    if dirty_count > 0 {
+        return Err(anyhow!(
+            "working tree has {dirty_count} uncommitted change(s); \
+             commit or stash them before creating a pull request"
+        ));
+    }
     let base_ref = git_find_base_ref(&repo_root)?;
     let ahead = git_commit_count(&repo_root, &format!("{base_ref}..HEAD"))?;
     if ahead == 0 {


### PR DESCRIPTION
Add a dirty-tree check at the entry of `create_pull_request_output()` to reject the operation when the working tree has uncommitted changes.

The function runs auto-rebase and auto-squash before pushing and creating a PR. Neither checks for a dirty working tree.

Reuses the existing `count_pending_changes()` helper (`repo.rs:671`).

## Testing
- [x] `cargo build` — compiles
- [x] `cargo clippy` — no warnings
- [x] `cargo test -p orangu --lib` — all 277 passed

Closes #204