### PR TITLE
Refuse OpenCL backend on Apple targets instead of crashing

### DIFF
--- a/src/bin/orangu-server/engine/backend/opencl.rs
+++ b/src/bin/orangu-server/engine/backend/opencl.rs
@@ -23,7 +23,10 @@
 //! registered, so [`OpenClBackend::try_init`] finds zero platforms here and
 //! gracefully returns `None`, the same as every other machine with no
 //! OpenCL device — this module's cross-check tests skip in exactly that
-//! case, per the same convention `vulkan.rs`/`cuda.rs` use.
+//! case, per the same convention `vulkan.rs`/`cuda.rs` use. Apple targets
+//! are the one exception: their OpenCL ICD does report a device, but
+//! segfaults on the first real matmul call, so `try_init` refuses to
+//! initialize there at all rather than crash.
 //!
 //! **Always compiled in**, like `cudarc`/`wgpu` — no Cargo feature needed.
 //! The `opencl3` version resolved here defaults to its `dynamic` feature
@@ -457,6 +460,12 @@ impl OpenClBackend {
     /// otherwise fails — callers fall back to `CpuBackend`, the same
     /// contract `VulkanBackend`/`CudaBackend::try_init` have.
     pub fn try_init() -> Option<Self> {
+        // Apple's own OpenCL ICD reports a device but segfaults inside
+        // clSetKernelArg on the first real matmul call (confirmed on Apple
+        // Silicon). Refuse to initialize there rather than crash.
+        if cfg!(target_vendor = "apple") {
+            return None;
+        }
         let device_id = *get_all_devices(CL_DEVICE_TYPE_GPU).ok()?.first()?;
         let device = Device::new(device_id);
         let device_name = device.name().unwrap_or_else(|_| "OpenCL".to_string());

--- a/src/bin/orangu-server/engine/backend/vulkan.rs
+++ b/src/bin/orangu-server/engine/backend/vulkan.rs
@@ -11871,7 +11871,7 @@ impl VulkanBackend {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_vendor = "apple")))]
 impl VulkanBackend {
     /// Test-only: build a layer's cached pre-attention resources so the replay
     /// cross-checks can enumerate the exact buffers the `attn_norm` dispatch
@@ -11944,7 +11944,7 @@ impl VulkanBackend {
 
 /// The buffers backing one layer's `attn_norm` dispatch, handed to the
 /// raw-Vulkan replay cross-check. Test-only.
-#[cfg(test)]
+#[cfg(all(test, not(target_vendor = "apple")))]
 pub(crate) struct AttnNormCaptureBuffers {
     pub n_embd_bytes: u64,
     pub x_buf: wgpu::Buffer,
@@ -11959,7 +11959,7 @@ pub(crate) struct AttnNormCaptureBuffers {
 /// the replay cross-check. Test-only. The weight comes from
 /// [`VulkanBackend::test_weight_buffer`]; the `Meta` uniform the replay rebuilds
 /// host-side (its values are all known constants).
-#[cfg(test)]
+#[cfg(all(test, not(target_vendor = "apple")))]
 pub(crate) struct OpCaptureBuffers {
     pub x_buffer: wgpu::Buffer,
     pub x_offset: u64,

--- a/src/bin/orangu-server/main.rs
+++ b/src/bin/orangu-server/main.rs
@@ -1218,10 +1218,7 @@ fn select_backend(preference: BackendPreference) -> Result<(Arc<dyn Backend>, St
                 let label = format!("CUDA/{}", backend.device_name);
                 return Ok((Arc::new(backend), label));
             }
-            // Apple's OpenCL driver segfaults on the first matmul call.
-            if !cfg!(target_vendor = "apple")
-                && let Some(backend) = engine::backend::OpenClBackend::try_init()
-            {
+            if let Some(backend) = engine::backend::OpenClBackend::try_init() {
                 let label = format!("OpenCL/{}", backend.device_name);
                 return Ok((Arc::new(backend), label));
             }


### PR DESCRIPTION
## Summary

- Apple's own OpenCL ICD reports a device, so OpenClBackend::try_init succeeds, but the first real matmul call segfaults inside clSetKernelArg (confirmed on an Apple Silicon Mac). This crashed backend = auto, an explicit backend = opencl, and cargo test itself (engine::backend::opencl::tests, which assumed try_init always returns None on a machine with no vendor ICD registered).
- try_init now refuses to initialize at all on Apple targets, so every caller (backend selection and the test suite) gets the same graceful None it already handles everywhere else. select_backend's Auto case drops the now-redundant Apple-specific check this replaces.
- Also gates vulkan.rs's test-only capture helpers (only consumed by vulkan_replay.rs's Vulkan-only tests, already excluded on Apple) to match, fixing a cargo clippy --all-targets dead-code failure on macOS.
- Scoped to target_vendor = "apple" only: every change either compiles to nothing on other platforms or, in main.rs, restores the original unconditional code. No other backend or platform is affected.

## Test plan

- [x] cargo test --bin orangu-server on an Apple Silicon Mac: was a SIGSEGV crash, now 349 passed, 0 failed, 0 crashes
- [x] cargo fmt --all --check clean
- [x] cargo clippy --all-targets -- -D warnings clean (was failing with dead-code errors on macOS)
- [x] orangu-server system and a real chat completion still work correctly with backend = auto