### PR TITLE
Add YAML workflow language and execution

### DIFF
--- a/doc/cheatsheet/en/03-tools.md
+++ b/doc/cheatsheet/en/03-tools.md
@@ -19,11 +19,16 @@ beside the built-in ones. orangu connects; it does not launch them.
 
 | Command | What it does |
 | --- | --- |
-| `[mcp.<name>]` | A service in `orangu.conf`: its URL (usually ending in `/mcp`), `timeout`, `enabled`, `required`, `enabled_tools` / `disabled_tools`. |
-| `approval_mode = auto` | Or `prompt` (ask per call), `writes` (ask unless the tool is read-only), `deny`. Unattended and review runs deny what needs asking. |
-| `/mcp` `/mcp refresh` | What is connected, disabled or failed, and how many tools each gave; reconnect and rediscover. |
-| `/mcp add <name> <command>` | Write a profile and connect it; `/mcp remove <name>` drops it. |
-| `mcp__<server>__<tool>` | How they are named, so nothing collides; `/tools` lists them. Tools only. |
+| `[mcp.<name>]` | A configured Streamable HTTP service; URL, filters and approval are in `orangu.conf`. |
+| `/mcp` `/mcp refresh` | Show and reconnect; `/mcp add` / `remove` manage one. `/tools` lists `mcp__<server>__<tool>`. |
+
+## Workflow files
+
+| Command | What it does |
+| --- | --- |
+| `orangu --workflow run.yaml --dry-run` | Validate every job without executing. |
+| `orangu --workflow run.yaml` | Run the jobs in order. |
+| `orangu --workflow run.yaml` `status` `pause` `resume` `clear` | Inspect/pause/resume/clear the saved job state. |
 
 ## The rest of the stack
 

--- a/doc/manual/en/40-terminal.md
+++ b/doc/manual/en/40-terminal.md
@@ -22,7 +22,9 @@ The sync runs in the background so it never delays startup. Its progress and res
 | `-a`  | `--all`       | Reopen the workspace tabs that were open at the end of the last run. |
 | `-t`  | `--theme`     | Apply a theme to the terminal interface for this run. Built-in names and paths to `.theme` files are accepted. |
 | `-p`  | `--prompt`    | Run a single prompt or command and exit — no terminal UI and no session on disk. See One-shot mode below. |
-| `-q`  | `--quiet`     | Print nothing on success — the exit code is the result. Applies to the modes that print and exit (`-p`, `-l`, `-s`). |
+|       | `--workflow FILE` | Validate and execute every job in a YAML workflow. |
+|       | `--dry-run FILE` | Validate a YAML workflow completely without executing it or loading configuration. |
+| `-q`  | `--quiet`     | Print nothing on success — the exit code is the result. Applies to the modes that print and exit, including workflows. |
 | `-l`  | `--list`      | List all stored sessions as a `SESSION WORKSPACE BRANCH DATE` table and exit. |
 | `-i`  | `--init`      | Interactively create `~/.orangu/orangu.conf` and exit (see the Configuration chapter). |
 | `-s`  | `--shell-completions` | Print the shell completion script for the detected shell (`$SHELL`; bash, zsh, or fish) and exit. |
@@ -56,7 +58,7 @@ orangu -q -p "/export pr"    # writes the PDF, says nothing
 echo $?                      # 0, or 1 with the reason on stderr
 ```
 
-That is what makes it suit a crontab or a `~/.orangu/schedule` job: silent until the day it fails. It applies to the modes that print and exit — `-p`, `-l`, and `-s`. Combining it with `-i` or with the terminal interface is an error rather than a no-op, since neither has diagnostics to separate from its output.
+That is what makes it suit a crontab or a `~/.orangu/schedule` job: silent until the day it fails. It applies to the modes that print and exit — `-p`, `-l`, `-s`, and `--workflow` (including `--dry-run`). Combining it with `-i` or with the terminal interface is an error rather than a no-op, since neither has diagnostics to separate from its output.
 
 `-t`/`--theme` is the other way round: a theme paints the interface — including the terminal's own background and foreground — so it takes effect only when there is an interface. A one-shot ignores it rather than repainting the terminal it printed into.
 

--- a/doc/manual/en/45-workflows.md
+++ b/doc/manual/en/45-workflows.md
@@ -1,0 +1,283 @@
+\newpage
+
+# Workflow files
+
+A workflow file describes a set of jobs and the ordered Orangu operations to
+run in each workspace. It is a thin YAML layer over the same slash commands,
+natural-language prompts, skills, and tools available through `orangu -p`.
+
+Validate the complete file before starting it:
+
+```text
+orangu --workflow export-prs.yaml --dry-run
+orangu --workflow export-prs.yaml
+```
+
+`--workflow --dry-run` loads no model configuration and executes nothing. It checks
+every job, workspace, variable, function call, approval, loop definition,
+control-flow construct, and explicit slash command. `--workflow` performs the
+same preflight before it loads configuration or starts the first job.
+
+## Complete file
+
+The following workflow runs `/export pr` in two projects and collects both
+PDFs in one explicitly approved directory:
+
+```yaml
+orangu:
+  version: 1
+  role: all
+  variables:
+    upstream: /home/me/Upstream
+  jobs:
+    - job: pgagroal
+      workspace: /home/me/PostgreSQL/pgagroal
+    - job: orangu
+      workspace: /home/me/Company/orangu
+  functions:
+    export_pr:
+      - command: /export pr
+    move_pdf:
+      - command: /shell mv ${job}-pr.pdf ${upstream}/
+  main:
+    - approved: ${upstream}
+    - call: export_pr
+    - call: move_pdf
+```
+
+The root key is `orangu`. `version` is required and is currently `1`. `jobs`
+and `main` must both be non-empty. Unknown keys are errors rather than ignored
+configuration.
+
+## Jobs, roles, and conversations
+
+Each `jobs` entry requires a unique `job` name and an existing `workspace`
+directory. Jobs run sequentially in declaration order and stop at the first
+failure. The complete `main` sequence runs once for every job, with `${job}`
+set to that job's name.
+
+`role` may be declared once under `orangu` or overridden by a job. It defaults
+to `all`; the other v1 values are `code`, `review`, `explorer`, and
+`embeddings`. When the configured endpoint is an Orangu coordinator, the role
+is sent to it for routing. Otherwise Orangu selects a configured server with
+that role, falling back to the default server.
+
+Command steps that reach the model share one conversation within their job.
+The next job starts a separate conversation in its own workspace.
+
+## Variables
+
+Top-level `variables` apply to every job. A job may add variables or override a
+top-level value:
+
+```yaml
+  variables:
+    profile: release
+  jobs:
+    - job: server
+      workspace: server
+      variables:
+        profile: debug
+```
+
+Values may be strings, integers, floating-point numbers, or booleans and are
+inserted with `${name}`. Variables may refer to other variables. `${job}` is
+reserved for the current job name and cannot be redefined. Undefined,
+recursive, malformed, or unterminated references fail validation.
+
+## Functions and execution order
+
+`functions` contains named, reusable lists of steps. A `call` expands a
+function at that exact position, so `main` is the single unambiguous execution
+order:
+
+```yaml
+  functions:
+    build:
+      - command: /build release
+    explain:
+      - command: Explain any build warnings and fix actionable ones.
+  main:
+    - call: build
+    - call: explain
+```
+
+Functions may call other functions. Unknown calls and direct or indirect
+recursion are validation errors. Function and variable names start with a
+letter or underscore and contain only letters, digits, and underscores.
+
+## Step types
+
+Version 1 has eleven explicit step types. A step contains exactly one of them.
+`command`, `call`, `approved`, and `loop` are the basic operations;
+`if`, `for`, `while`, `break`, `return`, `label`, and `goto` are the
+workflow's programming constructs. `loop` is one of those constructs: a
+bounded code-and-review cycle, not a separate command.
+
+### `command`
+
+The value is offered to Orangu's existing dispatcher:
+
+```yaml
+  main:
+    - command: /status
+    - command: /code-review authentication
+    - command: Investigate the failing authentication test and fix it.
+```
+
+A built-in slash command runs locally, a workspace skill expands into a model
+prompt, and other text is a natural-language model prompt. Preflight rejects
+unknown slash commands, missing required arguments, and commands that require
+the interactive terminal or persistent terminal session.
+
+### `call`
+
+`call` inserts a named function's steps. Expansion happens separately for each
+job, after its variables and `${job}` have been resolved.
+
+### `approved`
+
+An external path supplied through a variable requires an earlier `approved`
+step. One path or a list of paths may be approved:
+
+```yaml
+  main:
+    - approved:
+        - ${reports}
+        - ${archives}
+    - command: /shell mv report.pdf ${reports}/
+```
+
+Approved paths must already exist. Approval is ordered: placing it after the
+command does not authorize that command. An approval authorizes later uses
+wherever the run reaches them, including inside a called function or after
+it returns. It is an explicit workflow-language
+opt-in for passing a variable-derived external path; it does not widen the
+roots of Orangu's file tools.
+
+File and directory tools reject absolute, `..`, and symlinked paths that leave
+the job workspace, and a tool's `cwd` must remain inside it. `/shell` explicitly
+invokes the user's platform shell and is not an operating-system sandbox.
+Literal shell syntax therefore retains the existing `/shell` semantics.
+
+### `loop`
+
+A loop repeats a tool-enabled work phase followed by an independent,
+tool-free review phase:
+
+```yaml
+  functions:
+    improve_parser:
+      - loop:
+          objective: Fix ${job}'s parser without changing its public API.
+          stop:
+            type: goal
+            condition: All parser tests pass and review finds no regression.
+          review:
+            checks:
+              - cargo test
+            rubric:
+              - correctness
+              - backward compatibility
+  main:
+    - call: improve_parser
+```
+
+Every iteration gives the worker the objective and the previous review. After
+the work phase, Orangu runs the configured checks in the job workspace. The
+reviewer receives the worker report, check results, and branch diff, but no
+tools. Its response becomes feedback for the next iteration.
+
+Each loop has exactly one stopping policy:
+
+| `stop.type` | Required field | Meaning |
+| --- | --- | --- |
+| `turns` | `count` | Stop after a positive number of complete iterations. |
+| `time` | `duration` | Stop at a safe boundary after active time such as `30m` or `2h`. |
+| `goal` | `condition` | Continue until the reviewer verifies the stated condition. |
+
+Durations use `s`, `m`, `h`, or `d`. Orangu never interrupts a tool call or
+review response merely because the duration has elapsed. For a goal loop, the
+reviewer must end with the exact standalone line `LOOP_COMPLETE: yes`; an
+inline mention or optimistic wording does not complete it.
+
+`review.checks` and `review.rubric` are optional lists. Variables are expanded
+in the objective, stop value, checks, and rubric. The default rubric covers
+correctness, regressions, tests, and maintainability; listed entries add
+workflow-specific criteria.
+
+### `if`, `for`, `while`, `break`, `return`, `label`, `goto`
+
+Workflows are a small programming language over the steps above. Conditions
+are ordinary workflow commands run in the job session: success means true
+and failure selects the other branch instead of failing the job.
+
+```yaml
+  main:
+    - if:
+        condition: /shell test -f report.pdf
+        then:
+          - command: /shell mv report.pdf ${reports}/
+        else:
+          - command: /export pr
+    - for:
+        var: target
+        items: [alpha, beta]
+        do:
+          - command: /build ${target}
+    - while:
+        condition: /shell test ! -f done.txt
+        max_turns: 10
+        do:
+          - command: /test
+          - break: true
+    - label: finished
+    - goto: finished
+```
+
+`for` repeats its `do` steps once per item, with `${var}` set to that
+value. Instead of `items`, a finite `range` such as `1..3` may be given.
+At most 100 items (a range span of at most 1000) are allowed, and a loop
+variable cannot shadow an outer one or be used in an `approved` path.
+`while` re-evaluates its condition before every turn and stops after
+`max_turns` turns at the latest (between 1 and 1000, required).
+`break` stops the innermost enclosing `for` or `while` and is rejected
+outside one. `return` stops the current function after its `call` and is
+rejected in `main`. Labels address the step list that declares them: a
+`goto` must name a label from the same function or `main` list, so a jump
+never crosses a function boundary or implicitly enters a nested block.
+
+Every branch, condition, and loop body is validated before execution,
+including the slash-command preflight, so an error in a rarely taken
+branch still fails `--dry-run` rather than an hours-long run.
+
+## Managing a workflow
+
+Loop progress is stored in Orangu's workspace cache rather than in the
+repository. The workflow file supplies the jobs and their workspaces; append a
+lifecycle action after the file to inspect or control the saved loop for every
+job:
+
+```text
+orangu --workflow /path/to/workflow.yml status
+orangu --workflow /path/to/workflow.yml pause
+orangu --workflow /path/to/workflow.yml resume
+orangu --workflow /path/to/workflow.yml clear
+```
+
+`status` reports the objective, policy, iteration count, active time, and most
+recent review for each job. `pause` stops an active loop at its next safe phase
+boundary. `resume` continues a paused or failed loop with its saved review
+feedback. `clear` cancels saved state so another loop may start. A
+per-workspace lock prevents two loops from running against the same checkout
+simultaneously.
+
+## Operational behavior
+
+- `-q` suppresses successful workflow output. Failures still write to stderr
+  and return a non-zero exit status.
+- A loop can modify its workspace but does not commit, push, or open a pull
+  request unless an explicit workflow command does so.
+- Review evidence is bounded before it is sent to the model. Truncation is
+  marked rather than silently treated as complete evidence.
+- Saved loop state is control metadata, not a persisted model conversation.

--- a/src/bin/orangu/loop.rs
+++ b/src/bin/orangu/loop.rs
@@ -1,0 +1,958 @@
+// Copyright (C) 2026 The orangu community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Bounded code-and-review loops as a step of the `--workflow` language.
+//!
+//! Loops are not a standalone command: a workflow file declares them with a
+//! `loop` step, and `orangu --workflow FILE status|pause|resume|clear`
+//! inspects or controls the saved loop for every job in that file.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use crate::workflow::{WorkflowLoop, WorkflowLoopStop};
+use anyhow::{Context, Result, anyhow, bail};
+use orangu::config::ClientAppConfiguration;
+use orangu::llm::{StreamMetrics, normalized_openai_endpoint};
+use orangu::session::ChatSession;
+use orangu::skills::SkillRegistry;
+use orangu::tools::ToolExecutor;
+use serde::{Deserialize, Serialize};
+
+use crate::commands::build_workspace_system_prompt;
+use crate::git::collect_review_diff;
+use crate::models::{coordinator_role_profile, is_active_connection_a_coordinator};
+
+const MAX_REVIEW_INPUT_BYTES: usize = 48_000;
+const MAX_CHECK_OUTPUT_BYTES: usize = 12_000;
+const MAX_SAVED_REVIEW_BYTES: usize = 4_000;
+const LOOP_STATE_VERSION: u32 = 1;
+const LOOP_STATE_FILE: &str = "active.yaml";
+const LOOP_LOCK_FILE: &str = "running.lock";
+
+/// Manage the single persisted loop for a workspace. Workflow lifecycle
+/// actions (`orangu --workflow FILE status|pause|resume|clear`) map to these.
+#[derive(Clone, Copy, Debug)]
+enum LoopAction {
+    Status,
+    Pause,
+    Resume,
+    Clear,
+}
+
+pub(crate) struct LoopRunContext {
+    pub(crate) config: ClientAppConfiguration,
+    pub(crate) workspace: PathBuf,
+    /// The workflow job's role, used for server routing.
+    pub(crate) role: Option<String>,
+    pub(crate) quiet: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LoopSpec {
+    objective: String,
+    stop: StopPolicy,
+    review: ReviewConfig,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum StopPolicy {
+    Turns(u32),
+    Time(Duration),
+    Goal(String),
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct ReviewConfig {
+    #[serde(default)]
+    checks: Vec<String>,
+    #[serde(default)]
+    rubric: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedLoop {
+    version: u32,
+    state: LoopState,
+    objective: String,
+    stop: PersistedStopPolicy,
+    review: ReviewConfig,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    role: Option<String>,
+    iterations: u32,
+    active_seconds: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_review: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    failure: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum LoopState {
+    Active,
+    Paused,
+    Complete,
+    TurnLimitReached,
+    TimeLimitReached,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+enum PersistedStopPolicy {
+    Turns { count: u32 },
+    Time { seconds: u64 },
+    Goal { condition: String },
+}
+
+impl From<WorkflowLoop> for LoopSpec {
+    fn from(spec: WorkflowLoop) -> Self {
+        let stop = match spec.stop {
+            WorkflowLoopStop::Turns(count) => StopPolicy::Turns(count),
+            WorkflowLoopStop::Time(duration) => StopPolicy::Time(duration),
+            WorkflowLoopStop::Goal(condition) => StopPolicy::Goal(condition),
+        };
+        Self {
+            objective: spec.objective,
+            stop,
+            review: ReviewConfig {
+                checks: spec.checks,
+                rubric: spec.rubric,
+            },
+        }
+    }
+}
+
+impl PersistedLoop {
+    fn new(spec: LoopSpec, role: Option<String>) -> Self {
+        Self {
+            version: LOOP_STATE_VERSION,
+            state: LoopState::Active,
+            objective: spec.objective,
+            stop: PersistedStopPolicy::from_stop(spec.stop),
+            review: spec.review,
+            role,
+            iterations: 0,
+            active_seconds: 0,
+            last_review: None,
+            failure: None,
+        }
+    }
+
+    fn to_spec(&self) -> LoopSpec {
+        LoopSpec {
+            objective: self.objective.clone(),
+            stop: self.stop.to_stop(),
+            review: self.review.clone(),
+        }
+    }
+
+    fn is_terminal(&self) -> bool {
+        matches!(
+            self.state,
+            LoopState::Complete
+                | LoopState::TurnLimitReached
+                | LoopState::TimeLimitReached
+                | LoopState::Cancelled
+        )
+    }
+
+    fn status_report(&self) -> String {
+        let mut report = format!(
+            "Loop status: {}\nObjective: {}\nStopping policy: {}\nCompleted iterations: {}\nActive time: {} second(s)\n",
+            self.state.describe(),
+            self.objective,
+            self.stop.to_stop().describe(),
+            self.iterations,
+            self.active_seconds,
+        );
+        if let Some(role) = &self.role {
+            report.push_str(&format!("Role: {role}\n"));
+        }
+        if let Some(failure) = &self.failure {
+            report.push_str(&format!("Last failure: {failure}\n"));
+        }
+        if let Some(review) = &self.last_review {
+            report.push_str(&format!("Last review:\n{review}\n"));
+        }
+        report
+    }
+}
+
+impl LoopState {
+    fn describe(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Paused => "paused",
+            Self::Complete => "complete",
+            Self::TurnLimitReached => "turn limit reached",
+            Self::TimeLimitReached => "time limit reached",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+impl PersistedStopPolicy {
+    fn from_stop(stop: StopPolicy) -> Self {
+        match stop {
+            StopPolicy::Turns(count) => Self::Turns { count },
+            StopPolicy::Time(duration) => Self::Time {
+                seconds: duration.as_secs(),
+            },
+            StopPolicy::Goal(condition) => Self::Goal { condition },
+        }
+    }
+
+    fn to_stop(&self) -> StopPolicy {
+        match self {
+            Self::Turns { count } => StopPolicy::Turns(*count),
+            Self::Time { seconds } => StopPolicy::Time(Duration::from_secs(*seconds)),
+            Self::Goal { condition } => StopPolicy::Goal(condition.clone()),
+        }
+    }
+}
+
+fn loop_state_path(workspace: &Path) -> PathBuf {
+    orangu::workspace_cache::workspace_cache_dir(workspace, "loops").join(LOOP_STATE_FILE)
+}
+
+fn loop_lock_path(state_path: &Path) -> PathBuf {
+    state_path.with_file_name(LOOP_LOCK_FILE)
+}
+
+struct LoopLock {
+    path: PathBuf,
+}
+
+impl LoopLock {
+    fn acquire(state_path: &Path) -> Result<Self> {
+        let path = loop_lock_path(state_path);
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .with_context(|| {
+                format!(
+                    "a loop is already running for this workspace; inspect it with `orangu --workflow FILE status` ({})",
+                    path.display()
+                )
+            })?;
+        let _ = writeln!(file, "pid={}", std::process::id());
+        Ok(Self { path })
+    }
+}
+
+impl Drop for LoopLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+fn load_state(path: &Path) -> Result<PersistedLoop> {
+    let source = std::fs::read_to_string(path).with_context(|| {
+        format!(
+            "no saved loop for this workspace; run the workflow first ({})",
+            path.display()
+        )
+    })?;
+    let state: PersistedLoop = serde_yaml::from_str(&source)
+        .with_context(|| format!("invalid saved loop state {}", path.display()))?;
+    if state.version != LOOP_STATE_VERSION {
+        bail!(
+            "unsupported saved loop version {}; expected {LOOP_STATE_VERSION}",
+            state.version
+        );
+    }
+    Ok(state)
+}
+
+fn save_state(path: &Path, state: &PersistedLoop) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("saved loop state has no parent directory")?;
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create loop state directory {}", parent.display()))?;
+    let content = serde_yaml::to_string(state).context("failed to serialize loop state")?;
+    let temporary = path.with_extension("yaml.tmp");
+    std::fs::write(&temporary, content)
+        .with_context(|| format!("failed to write loop state {}", temporary.display()))?;
+    std::fs::rename(&temporary, path)
+        .with_context(|| format!("failed to save loop state {}", path.display()))
+}
+
+fn active_elapsed(active_seconds_before_resume: u64, resumed_at: Instant) -> Duration {
+    Duration::from_secs(active_seconds_before_resume).saturating_add(resumed_at.elapsed())
+}
+
+fn checkpoint(
+    path: &Path,
+    state: &mut PersistedLoop,
+    active_seconds_before_resume: u64,
+    resumed_at: Instant,
+) -> Result<()> {
+    state.active_seconds = active_elapsed(active_seconds_before_resume, resumed_at).as_secs();
+    if let Ok(saved) = load_state(path)
+        && saved.state != LoopState::Active
+    {
+        state.state = saved.state;
+    }
+    save_state(path, state)
+}
+
+/// Run a loop declared by a workflow `loop` step. Saved state lives in the
+/// workspace cache so `orangu --workflow FILE status|pause|resume|clear` can
+/// inspect or control it for every job in that file.
+pub(crate) async fn run_workflow(spec: WorkflowLoop, context: LoopRunContext) -> Result<()> {
+    start(spec.into(), context).await
+}
+
+pub(crate) async fn workflow_action(action: &str, context: LoopRunContext) -> Result<()> {
+    let action = match action {
+        "status" => LoopAction::Status,
+        "pause" => LoopAction::Pause,
+        "resume" => LoopAction::Resume,
+        "clear" => LoopAction::Clear,
+        _ => bail!("unknown workflow action '{action}'"),
+    };
+    manage_loop(action, context).await
+}
+
+async fn start(spec: LoopSpec, context: LoopRunContext) -> Result<()> {
+    let state_path = loop_state_path(&context.workspace);
+    if let Ok(existing) = load_state(&state_path)
+        && matches!(existing.state, LoopState::Active | LoopState::Paused)
+    {
+        bail!(
+            "a {} loop is already saved for this workspace; use `orangu --workflow FILE status`, `pause`, `resume`, or `clear`",
+            existing.state.describe()
+        );
+    }
+    let state = PersistedLoop::new(spec, context.role.clone());
+    save_state(&state_path, &state)?;
+    run_persisted(state, context, state_path).await
+}
+
+async fn manage_loop(action: LoopAction, context: LoopRunContext) -> Result<()> {
+    let path = loop_state_path(&context.workspace);
+    match action {
+        LoopAction::Status => {
+            let state = load_state(&path)?;
+            if !context.quiet {
+                print!("{}", state.status_report());
+            }
+            Ok(())
+        }
+        LoopAction::Pause => {
+            let mut state = load_state(&path)?;
+            if state.is_terminal() {
+                bail!(
+                    "the saved loop is already {}; start a new loop instead",
+                    state.state.describe()
+                );
+            }
+            state.state = LoopState::Paused;
+            save_state(&path, &state)?;
+            if !context.quiet {
+                println!(
+                    "Loop pause requested. A running loop will stop at its next safe boundary."
+                );
+            }
+            Ok(())
+        }
+        LoopAction::Clear => {
+            let mut state = load_state(&path)?;
+            state.state = LoopState::Cancelled;
+            state.failure = None;
+            save_state(&path, &state)?;
+            if !context.quiet {
+                println!("Saved loop cancelled. A new workflow run may now replace it.");
+            }
+            Ok(())
+        }
+        LoopAction::Resume => {
+            let mut state = load_state(&path)?;
+            if loop_lock_path(&path).exists() {
+                bail!(
+                    "a loop is already running for this workspace; pause it or wait for its current phase to finish"
+                );
+            }
+            if state.is_terminal() && state.state != LoopState::Failed {
+                bail!(
+                    "the saved loop is {}; start a new loop instead",
+                    state.state.describe()
+                );
+            }
+            state.state = LoopState::Active;
+            state.failure = None;
+            save_state(&path, &state)?;
+            run_persisted(state, context, path).await
+        }
+    }
+}
+
+async fn run_persisted(
+    mut state: PersistedLoop,
+    context: LoopRunContext,
+    state_path: PathBuf,
+) -> Result<()> {
+    let _lock = LoopLock::acquire(&state_path)?;
+    let result = run_persisted_inner(&mut state, &context, &state_path).await;
+    if let Err(error) = &result {
+        state.state = LoopState::Failed;
+        state.failure = Some(format!("{error:#}"));
+        let _ = save_state(&state_path, &state);
+    }
+    result
+}
+
+async fn run_persisted_inner(
+    state: &mut PersistedLoop,
+    context: &LoopRunContext,
+    state_path: &Path,
+) -> Result<()> {
+    let LoopRunContext {
+        config,
+        workspace,
+        role,
+        quiet,
+    } = context;
+    let spec = state.to_spec();
+    let role = role.as_deref().or(state.role.as_deref());
+    let server = role
+        .map(|role| config.find_server_for_role(role))
+        .unwrap_or_else(|| config.default_server.clone());
+    let configured_profile = config
+        .llms
+        .get(&server)
+        .ok_or_else(|| anyhow!("missing configured server {server}"))?
+        .clone();
+    let profile = match role {
+        Some(role) => {
+            let endpoint = normalized_openai_endpoint(&configured_profile.endpoint);
+            let http_client = reqwest::Client::builder()
+                .timeout(Duration::from_secs(3))
+                .build()?;
+            if is_active_connection_a_coordinator(&http_client, config, &server, Some(&endpoint))
+                .await
+            {
+                coordinator_role_profile(&configured_profile, &endpoint, role)
+            } else {
+                configured_profile
+            }
+        }
+        None => configured_profile,
+    };
+    let (mcp, warnings) =
+        orangu::mcp::McpManager::connect_all(&config.mcp_servers, workspace).await?;
+    for warning in warnings {
+        note(*quiet, &format!("Warning: {warning}"));
+    }
+    let tools = ToolExecutor::with_config(
+        workspace,
+        config.compression,
+        config.auto_downsample_lines,
+        config.diff_file_cap,
+        None,
+    )
+    .with_mcp(mcp.clone());
+    let skills = SkillRegistry::discover(workspace);
+    let mut system = build_workspace_system_prompt(&profile, &skills, workspace, None);
+    if !mcp.instructions().is_empty() {
+        system.push_str("\n\n");
+        system.push_str(&mcp.instructions());
+    }
+    let mut work_session = ChatSession::new(&system);
+    let review_system = format!(
+        "{system}\n\nYou are the review phase of an automated code loop. You are read-only: do not claim to have changed files, and base conclusions only on the supplied evidence."
+    );
+    let mut review_session = ChatSession::new(&review_system);
+    let resumed_at = Instant::now();
+    let active_seconds_before_resume = state.active_seconds;
+
+    note(
+        *quiet,
+        &format!(
+            "loop started: {} ({})",
+            spec.objective,
+            spec.stop.describe()
+        ),
+    );
+    loop {
+        if state.state != LoopState::Active {
+            finish(*quiet, state.iterations, "pause or cancellation requested");
+            return Ok(());
+        }
+        if let StopPolicy::Time(limit) = spec.stop
+            && state.iterations > 0
+            && active_elapsed(active_seconds_before_resume, resumed_at) >= limit
+        {
+            state.state = LoopState::TimeLimitReached;
+            checkpoint(state_path, state, active_seconds_before_resume, resumed_at)?;
+            finish(*quiet, state.iterations, "time limit reached");
+            return Ok(());
+        }
+        if let StopPolicy::Turns(limit) = spec.stop
+            && state.iterations >= limit
+        {
+            state.state = LoopState::TurnLimitReached;
+            checkpoint(state_path, state, active_seconds_before_resume, resumed_at)?;
+            finish(*quiet, state.iterations, "turn limit reached");
+            return Ok(());
+        }
+
+        let iteration = state.iterations + 1;
+        heading(*quiet, &format!("Iteration {iteration}: work"));
+        let work_prompt = render_work_prompt(
+            &spec,
+            iteration,
+            active_elapsed(active_seconds_before_resume, resumed_at),
+            state.last_review.as_deref(),
+        );
+        let work_answer = work_session
+            .prompt(
+                &work_prompt,
+                &profile,
+                &tools,
+                |delta| stream(*quiet, delta),
+                |_metrics: StreamMetrics| {},
+                |_running| {},
+                |tool_call| note(*quiet, &format!("[tool] {}", tool_call.function.name)),
+                |_| false,
+            )
+            .await
+            .context("work phase failed")?;
+        stream(*quiet, "\n");
+
+        let checks = run_checks(workspace, &spec.review.checks).await?;
+        let diff = review_diff_evidence(workspace);
+        heading(*quiet, &format!("Iteration {iteration}: review"));
+        let review_prompt = render_review_prompt(&spec, iteration, &work_answer, &diff, &checks);
+        let review = review_session
+            .prompt_without_tools(
+                &review_prompt,
+                &profile,
+                0,
+                |delta| stream(*quiet, delta),
+                |_metrics: StreamMetrics| {},
+            )
+            .await
+            .context("review phase failed")?;
+        stream(*quiet, "\n");
+
+        state.iterations = iteration;
+        state.last_review = Some(truncate_for_review(&review, MAX_SAVED_REVIEW_BYTES));
+        checkpoint(state_path, state, active_seconds_before_resume, resumed_at)?;
+
+        if state.state == LoopState::Active
+            && matches!(spec.stop, StopPolicy::Goal(_))
+            && reviewer_declared_complete(&review)
+        {
+            state.state = LoopState::Complete;
+            checkpoint(state_path, state, active_seconds_before_resume, resumed_at)?;
+            finish(*quiet, iteration, "goal condition verified by review");
+            return Ok(());
+        }
+    }
+}
+
+impl StopPolicy {
+    fn describe(&self) -> String {
+        match self {
+            Self::Turns(count) => format!("{count} iteration(s)"),
+            Self::Time(duration) => format!("{} active second(s)", duration.as_secs()),
+            Self::Goal(condition) => format!("until {condition}"),
+        }
+    }
+}
+
+fn render_work_prompt(
+    spec: &LoopSpec,
+    iteration: u32,
+    elapsed: Duration,
+    previous_review: Option<&str>,
+) -> String {
+    let feedback = previous_review.map_or_else(
+        || "No prior review is available; establish a working baseline.".to_string(),
+        |review| {
+            format!(
+                "Address this review feedback before pursuing new work:\n{}",
+                truncate_for_review(review, MAX_SAVED_REVIEW_BYTES)
+            )
+        },
+    );
+    format!(
+        "You are in iteration {iteration} of an automated code-and-review loop.\n\n\
+Objective:\n{}\n\n\
+Stopping policy: {}\nActive time so far: {} seconds.\n\n\
+Previous review:\n{feedback}\n\n\
+Make concrete progress toward the objective in the current workspace. Inspect the current state, change code when needed, and run relevant validation. Do not merely describe a proposed change. Keep the full objective intact even if this iteration cannot finish it. End with a concise account of changed files, validation, and unresolved risks; a separate reviewer will examine the result.",
+        spec.objective,
+        spec.stop.describe(),
+        elapsed.as_secs(),
+    )
+}
+
+fn render_review_prompt(
+    spec: &LoopSpec,
+    iteration: u32,
+    work_answer: &str,
+    diff: &str,
+    checks: &str,
+) -> String {
+    let rubric = if spec.review.rubric.is_empty() {
+        "correctness, regressions, tests, and maintainability".to_string()
+    } else {
+        spec.review.rubric.join(", ")
+    };
+    let condition = match &spec.stop {
+        StopPolicy::Goal(condition) => condition.as_str(),
+        StopPolicy::Turns(_) | StopPolicy::Time(_) => {
+            "not applicable; report remaining work honestly"
+        }
+    };
+    format!(
+        "Review iteration {iteration}.\n\n\
+Objective:\n{}\n\n\
+Completion condition:\n{condition}\n\n\
+Review rubric: {rubric}\n\n\
+Worker report:\n{}\n\n\
+Validation command results:\n{}\n\n\
+Current workspace diff:\n{}\n\n\
+Find concrete defects, missing verification, regressions, and risks. Do not claim the objective is complete without evidence from the supplied diff and validation output. End with exactly one standalone line: `LOOP_COMPLETE: yes` only when the completion condition is proved; otherwise `LOOP_COMPLETE: no`.",
+        spec.objective,
+        truncate_for_review(work_answer, MAX_REVIEW_INPUT_BYTES / 4),
+        truncate_for_review(checks, MAX_REVIEW_INPUT_BYTES / 4),
+        truncate_for_review(diff, MAX_REVIEW_INPUT_BYTES / 2),
+    )
+}
+
+async fn run_checks(workspace: &Path, commands: &[String]) -> Result<String> {
+    let workspace = workspace.to_path_buf();
+    let commands = commands.to_vec();
+    tokio::task::spawn_blocking(move || {
+        let mut results = String::new();
+        for command in commands {
+            let output = shell_command(&workspace, &command)
+                .with_context(|| format!("failed to run loop check '{command}'"))?;
+            results.push_str(&format!("$ {command}\n"));
+            results.push_str(&String::from_utf8_lossy(&output.stdout));
+            results.push_str(&String::from_utf8_lossy(&output.stderr));
+            results.push_str(&format!("exit: {}\n\n", output.status));
+        }
+        Ok::<_, anyhow::Error>(if results.is_empty() {
+            "No explicit validation commands were configured.".to_string()
+        } else {
+            truncate_for_review(&results, MAX_CHECK_OUTPUT_BYTES)
+        })
+    })
+    .await
+    .context("loop validation task failed")?
+}
+
+fn shell_command(workspace: &Path, command: &str) -> std::io::Result<std::process::Output> {
+    let (program, args) = orangu::shell::command_parts();
+    Command::new(program)
+        .args(args)
+        .arg(command)
+        .current_dir(workspace)
+        .output()
+}
+
+/// Build the same committed-plus-local evidence used by `/review`. Falling
+/// back to a worktree diff keeps loops useful in a non-Git workspace.
+fn review_diff_evidence(workspace: &Path) -> String {
+    match collect_review_diff(workspace) {
+        Ok(review) if review.files.is_empty() => format!(
+            "No changes compared with {} (including committed and local changes).",
+            review.base_label
+        ),
+        Ok(review) => {
+            let mut evidence = format!(
+                "Changes compared with {} (including committed and local changes):\n",
+                review.base_label
+            );
+            for file in review.files {
+                evidence.push_str(&format!("\n--- {} ---\n{}\n", file.path, file.patch));
+            }
+            evidence
+        }
+        Err(error) => workspace_diff(workspace, &format!("full branch diff unavailable: {error}")),
+    }
+}
+
+fn workspace_diff(workspace: &Path, reason: &str) -> String {
+    let output = Command::new("git")
+        .args(["-C"])
+        .arg(workspace)
+        .args(["diff", "--no-ext-diff", "--no-color"])
+        .output();
+    match output {
+        Ok(output) if output.status.success() => {
+            let diff = String::from_utf8_lossy(&output.stdout).to_string();
+            if diff.trim().is_empty() {
+                format!("{reason}; no uncommitted Git diff is available.")
+            } else {
+                diff
+            }
+        }
+        Ok(output) => format!(
+            "{reason}; Git diff unavailable: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ),
+        Err(err) => format!("{reason}; Git diff unavailable: {err}"),
+    }
+}
+
+fn reviewer_declared_complete(review: &str) -> bool {
+    review
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .is_some_and(|line| line.trim().eq_ignore_ascii_case("LOOP_COMPLETE: yes"))
+}
+
+fn truncate_for_review(value: &str, limit: usize) -> String {
+    if value.len() <= limit {
+        return value.to_string();
+    }
+    let mut end = limit;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}\n[truncated by Orangu]", &value[..end])
+}
+
+fn heading(quiet: bool, text: &str) {
+    if !quiet {
+        println!("\n--- {text} ---");
+    }
+}
+
+fn stream(quiet: bool, text: &str) {
+    if !quiet {
+        print!("{text}");
+        let _ = std::io::stdout().flush();
+    }
+}
+
+fn note(quiet: bool, text: &str) {
+    if !quiet {
+        eprintln!("{text}");
+    }
+}
+
+fn finish(quiet: bool, iterations: u32, reason: &str) {
+    if !quiet {
+        println!("\nLoop stopped after {iterations} iteration(s): {reason}.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+    use std::net::TcpListener;
+    use tempfile::NamedTempFile;
+
+    fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack
+            .windows(needle.len())
+            .position(|window| window == needle)
+    }
+
+    fn serve_loop_responses(listener: TcpListener) -> std::thread::JoinHandle<Vec<String>> {
+        std::thread::spawn(move || {
+            let responses = [
+                "data: {\"choices\":[{\"delta\":{\"content\":\"work complete\"},\"finish_reason\":null}]}\n\ndata: [DONE]\n\n",
+                "data: {\"choices\":[{\"delta\":{\"content\":\"LOOP_COMPLETE: yes\"},\"finish_reason\":null}]}\n\ndata: [DONE]\n\n",
+            ];
+            let mut bodies = Vec::new();
+            for response_body in responses {
+                let (mut stream, _) = listener.accept().expect("accept connection");
+                let mut request = Vec::new();
+                let mut buffer = [0u8; 4096];
+                let header_end = loop {
+                    let read = stream.read(&mut buffer).expect("read request");
+                    request.extend_from_slice(&buffer[..read]);
+                    if let Some(position) = find_subsequence(&request, b"\r\n\r\n") {
+                        break position + 4;
+                    }
+                };
+                let headers = String::from_utf8_lossy(&request[..header_end]).to_ascii_lowercase();
+                let content_length: usize = headers
+                    .lines()
+                    .find_map(|line| line.strip_prefix("content-length:"))
+                    .and_then(|value| value.trim().parse().ok())
+                    .unwrap_or(0);
+                while request.len() < header_end + content_length {
+                    let read = stream.read(&mut buffer).expect("read body");
+                    request.extend_from_slice(&buffer[..read]);
+                }
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    response_body.len(),
+                    response_body
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write response");
+                bodies.push(String::from_utf8_lossy(&request[header_end..]).to_string());
+            }
+            bodies
+        })
+    }
+
+    #[test]
+    fn workflow_loop_converts_to_the_loop_specification() {
+        let spec = LoopSpec::from(WorkflowLoop {
+            objective: "Fix parser".to_string(),
+            stop: WorkflowLoopStop::Goal("All tests pass".to_string()),
+            checks: vec!["cargo test".to_string()],
+            rubric: vec!["correctness".to_string()],
+        });
+        assert_eq!(spec.objective, "Fix parser");
+        assert_eq!(spec.stop, StopPolicy::Goal("All tests pass".to_string()));
+        assert_eq!(spec.review.checks, vec!["cargo test"]);
+        assert_eq!(spec.review.rubric, vec!["correctness"]);
+    }
+
+    #[test]
+    fn completion_marker_must_be_standalone() {
+        assert!(reviewer_declared_complete("LOOP_COMPLETE: yes\n"));
+        assert!(!reviewer_declared_complete("I think LOOP_COMPLETE: yes."));
+        assert!(!reviewer_declared_complete(
+            "LOOP_COMPLETE: yes\nBut there is still unresolved work."
+        ));
+        assert!(!reviewer_declared_complete("LOOP_COMPLETE: no"));
+    }
+
+    #[test]
+    fn saves_and_loads_resumable_state() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("active.yaml");
+        let state = PersistedLoop::new(
+            LoopSpec {
+                objective: "Harden authentication".to_string(),
+                stop: StopPolicy::Turns(3),
+                review: ReviewConfig {
+                    checks: vec!["cargo test".to_string()],
+                    rubric: vec!["security".to_string()],
+                },
+            },
+            Some("code".to_string()),
+        );
+        save_state(&path, &state).unwrap();
+        let loaded = load_state(&path).unwrap();
+        assert_eq!(loaded.objective, "Harden authentication");
+        assert!(matches!(
+            loaded.stop,
+            PersistedStopPolicy::Turns { count: 3 }
+        ));
+        assert_eq!(loaded.state, LoopState::Active);
+        assert_eq!(loaded.role.as_deref(), Some("code"));
+        assert!(loaded.status_report().contains("Role: code"));
+        assert!(loaded.status_report().contains("Completed iterations: 0"));
+    }
+
+    #[test]
+    fn checkpoint_preserves_resume_baseline() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("active.yaml");
+        let mut state = PersistedLoop::new(
+            LoopSpec {
+                objective: "Fix parser".to_string(),
+                stop: StopPolicy::Turns(2),
+                review: ReviewConfig::default(),
+            },
+            None,
+        );
+        state.active_seconds = 17;
+        save_state(&path, &state).unwrap();
+        let resumed_at = Instant::now();
+        checkpoint(&path, &mut state, 17, resumed_at).unwrap();
+        assert!(state.active_seconds >= 17);
+        assert!(state.active_seconds < 19);
+    }
+
+    #[test]
+    fn next_work_turn_receives_prior_review() {
+        let spec = LoopSpec {
+            objective: "Fix parser".to_string(),
+            stop: StopPolicy::Turns(2),
+            review: ReviewConfig::default(),
+        };
+        let prompt = render_work_prompt(
+            &spec,
+            2,
+            Duration::from_secs(5),
+            Some("The parser rejects escaped quotes."),
+        );
+        assert!(prompt.contains("The parser rejects escaped quotes."));
+        assert!(prompt.contains("Address this review feedback"));
+    }
+
+    #[tokio::test]
+    async fn one_iteration_runs_work_then_read_only_review_and_completes() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let endpoint = format!("http://{}/v1", listener.local_addr().expect("address"));
+        let server = serve_loop_responses(listener);
+        let root = tempfile::tempdir().expect("workspace");
+        let config_file = NamedTempFile::new().expect("config");
+        std::fs::write(
+            config_file.path(),
+            format!(
+                "[orangu]\nserver = test\nmodel = test-model\ntimeout = 5\n\n[test]\nrole = all\nendpoint = {endpoint}\nmodel = test-model\n"
+            ),
+        )
+        .expect("write config");
+        let config =
+            orangu::config::load_client_configuration(config_file.path()).expect("load config");
+        let mut state = PersistedLoop::new(
+            LoopSpec {
+                objective: "Finish the parser".to_string(),
+                stop: StopPolicy::Goal("The parser is complete".to_string()),
+                review: ReviewConfig::default(),
+            },
+            None,
+        );
+        let state_path = root.path().join("active.yaml");
+        let context = LoopRunContext {
+            config,
+            workspace: root.path().to_path_buf(),
+            role: None,
+            quiet: true,
+        };
+
+        run_persisted_inner(&mut state, &context, &state_path)
+            .await
+            .expect("loop iteration");
+
+        assert_eq!(state.state, LoopState::Complete);
+        assert_eq!(state.iterations, 1);
+        assert_eq!(state.last_review.as_deref(), Some("LOOP_COMPLETE: yes"));
+        let requests = server.join().expect("server thread");
+        assert!(requests[0].contains("\"tools\""));
+        assert!(!requests[1].contains("\"tools\""));
+        assert!(requests[1].contains("work complete"));
+    }
+}

--- a/src/bin/orangu/main.rs
+++ b/src/bin/orangu/main.rs
@@ -25,6 +25,7 @@ mod git;
 mod information;
 mod init;
 mod input;
+mod r#loop;
 mod manual;
 mod mode;
 mod models;
@@ -40,13 +41,14 @@ mod slash_command;
 mod stats;
 mod terminal;
 mod wait;
+mod workflow;
 mod workspace_tab;
 
 #[cfg(test)]
 mod test_support;
 
 use anyhow::{Context, Result, anyhow};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use crossterm::{
     event::{
         self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, KeyboardEnhancementFlags,
@@ -164,6 +166,42 @@ struct Args {
     /// console and exit.
     #[arg(short = 'p', long = "prompt")]
     prompt: Option<String>,
+    /// Validate and execute every job in a YAML workflow.
+    #[arg(
+        long = "workflow",
+        value_name = "FILE",
+        conflicts_with_all = [
+            "theme",
+            "workspace",
+            "resume",
+            "all",
+            "list",
+            "init",
+            "prompt",
+            "shell_completions",
+            "build_cheatsheet",
+            "build_manual"
+        ]
+    )]
+    workflow: Option<PathBuf>,
+    /// Validate a YAML workflow completely without loading configuration or
+    /// executing any job.
+    #[arg(
+        long = "dry-run",
+        conflicts_with_all = [
+            "theme",
+            "workspace",
+            "resume",
+            "all",
+            "list",
+            "init",
+            "prompt",
+            "shell_completions",
+            "build_cheatsheet",
+            "build_manual"
+        ]
+    )]
+    dry_run: bool,
     /// Print nothing on success: no answer, no command output, no diagnostics.
     #[arg(short = 'q', long = "quiet")]
     quiet: bool,
@@ -190,6 +228,20 @@ struct Args {
         hide = true
     )]
     build_manual: Option<Vec<PathBuf>>,
+    #[command(subcommand)]
+    command: Option<CliCommand>,
+}
+
+#[derive(Subcommand, Debug)]
+enum CliCommand {
+    /// Show the saved loop state for every job in a workflow.
+    Status,
+    /// Pause every active loop in a workflow at its next safe boundary.
+    Pause,
+    /// Resume every paused or failed loop in a workflow.
+    Resume,
+    /// Cancel every saved loop in a workflow.
+    Clear,
 }
 
 /// Pick the completion script for a `$SHELL` value. Separate from printing it
@@ -235,6 +287,8 @@ fn quiet_refusal(args: &Args) -> Option<&'static str> {
         || args.list
         || args.build_cheatsheet.is_some()
         || args.build_manual.is_some()
+        || args.workflow.is_some()
+        || args.dry_run
     {
         return None;
     }
@@ -244,13 +298,42 @@ fn quiet_refusal(args: &Args) -> Option<&'static str> {
              is a dialogue, and its questions are the output",
         );
     }
-    if args.prompt.is_none() {
+    if args.prompt.is_none() && args.command.is_none() {
         return Some(
             "-q/--quiet applies to the modes that print and exit (-p, -l, -s); \
              the terminal interface has nothing to silence",
         );
     }
     None
+}
+
+fn command_mode_refusal(args: &Args) -> Option<&'static str> {
+    args.command.as_ref()?;
+    let workflow_action = matches!(
+        args.command.as_ref(),
+        Some(CliCommand::Status | CliCommand::Pause | CliCommand::Resume | CliCommand::Clear)
+    );
+    if workflow_action && args.workflow.is_none() {
+        return Some("workflow lifecycle actions require --workflow FILE");
+    }
+    if (args.workflow.is_some() && !workflow_action)
+        || args.dry_run
+        || args.theme.is_some()
+        || args.resume.is_some()
+        || args.all
+        || args.list
+        || args.init
+        || args.prompt.is_some()
+        || args.shell_completions
+        || args.build_cheatsheet.is_some()
+        || args.build_manual.is_some()
+    {
+        Some(
+            "a CLI subcommand cannot be combined with another execution mode; only --config, --workspace, and --quiet are accepted with a workflow lifecycle action",
+        )
+    } else {
+        None
+    }
 }
 
 fn main() -> ExitCode {
@@ -279,6 +362,9 @@ fn main() -> ExitCode {
 
 async fn run() -> Result<()> {
     let mut args = Args::parse();
+    if let Some(refusal) = command_mode_refusal(&args) {
+        return Err(anyhow!(refusal));
+    }
     if let Some(refusal) = quiet_refusal(&args) {
         return Err(anyhow!(refusal));
     }
@@ -319,6 +405,28 @@ async fn run() -> Result<()> {
     if args.init {
         return init::run_init().await;
     }
+    if args.dry_run {
+        let path = args
+            .workflow
+            .take()
+            .ok_or_else(|| anyhow!("--dry-run requires --workflow FILE"))?;
+        let plan = load_workflow(&path)?;
+        if !args.quiet {
+            println!(
+                "workflow is valid: {} job{}",
+                plan.jobs.len(),
+                if plan.jobs.len() == 1 { "" } else { "s" }
+            );
+        }
+        return Ok(());
+    }
+    // Compile every job before loading configuration or starting the first
+    // potentially long-running step.
+    let workflow = args
+        .workflow
+        .take()
+        .map(|path| load_workflow(&path))
+        .transpose()?;
     let config_path = match args.config.or_else(default_client_config_path) {
         Some(path) => path,
         None => {
@@ -328,6 +436,19 @@ async fn run() -> Result<()> {
         }
     };
     let config = load_client_configuration(&config_path)?;
+    if let Some(plan) = workflow {
+        let action = match args.command.take() {
+            Some(CliCommand::Status) => Some("status"),
+            Some(CliCommand::Pause) => Some("pause"),
+            Some(CliCommand::Resume) => Some("resume"),
+            Some(CliCommand::Clear) => Some("clear"),
+            None => None,
+        };
+        if let Some(action) = action {
+            return workflow::manage(plan, config, args.quiet, action).await;
+        }
+        return workflow::run(plan, config, config_path, args.quiet).await;
+    }
     // A one-shot prints a report and exits. Applying a theme here would emit the
     // OSC sequences that repaint the terminal's own background and foreground —
     // a lasting change to someone else's terminal, and output where `-q`
@@ -339,6 +460,7 @@ async fn run() -> Result<()> {
                 workspace: resolve_workspace_root(args.workspace)?,
                 config,
                 config_path,
+                role: None,
                 quiet: args.quiet,
             },
         )
@@ -2561,6 +2683,17 @@ async fn run() -> Result<()> {
     Ok(())
 }
 
+fn load_workflow(path: &Path) -> Result<workflow::WorkflowPlan> {
+    let source = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read workflow {}", path.display()))?;
+    let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let plan = workflow::compile(&source, base_dir)
+        .with_context(|| format!("failed to validate workflow {}", path.display()))?;
+    workflow::validate(&plan)
+        .with_context(|| format!("failed to validate workflow {}", path.display()))?;
+    Ok(plan)
+}
+
 fn llm_prompt_block_reason(
     endpoint: Option<&str>,
     _header_status: orangu::tui::HeaderStatus,
@@ -2664,11 +2797,15 @@ pub fn process_env_lock() -> &'static std::sync::Mutex<()> {
 
 #[cfg(test)]
 mod tests {
-
-    use super::{Args, completion_script, llm_prompt_block_reason, quiet_refusal};
+    use super::{
+        Args, command_mode_refusal, completion_script, llm_prompt_block_reason, load_workflow,
+        quiet_refusal,
+    };
     use clap::Parser;
 
     use orangu::tui::{ConnStatus, HeaderStatus};
+    use std::fs;
+    use tempfile::tempdir;
 
     fn args(argv: &[&str]) -> Args {
         Args::parse_from(std::iter::once("orangu").chain(argv.iter().copied()))
@@ -2679,6 +2816,11 @@ mod tests {
         assert_eq!(quiet_refusal(&args(&["-q", "-p", "/help"])), None);
         assert_eq!(quiet_refusal(&args(&["-q", "-l"])), None);
         assert_eq!(quiet_refusal(&args(&["-q", "-s"])), None);
+        assert_eq!(quiet_refusal(&args(&["-q", "--workflow", "run.yml"])), None);
+        assert_eq!(
+            quiet_refusal(&args(&["-q", "--workflow", "run.yml", "--dry-run"])),
+            None
+        );
         // Without -q there is nothing to refuse, whatever the mode.
         assert_eq!(quiet_refusal(&args(&["-i"])), None);
         assert_eq!(quiet_refusal(&args(&[])), None);
@@ -2716,6 +2858,138 @@ mod tests {
         assert!(err.contains("nonesuch"), "{err}");
         assert!(err.contains("bash, zsh, fish"), "{err}");
         assert!(completion_script("").is_err());
+    }
+
+    #[test]
+    fn workflow_modes_conflict_with_interactive_inputs() {
+        for argv in [
+            vec!["orangu", "--workflow", "run.yml", "--prompt", "/status"],
+            vec![
+                "orangu",
+                "--workflow",
+                "run.yml",
+                "--dry-run",
+                "--workspace",
+                ".",
+            ],
+        ] {
+            assert!(Args::try_parse_from(argv.clone()).is_err(), "{argv:?}");
+        }
+        assert!(command_mode_refusal(&args(&["status"])).is_some());
+        assert_eq!(
+            command_mode_refusal(&args(&["--workflow", "run.yml", "status"])),
+            None
+        );
+    }
+
+    #[test]
+    fn workflow_lifecycle_action_requires_workflow_file() {
+        assert!(command_mode_refusal(&args(&["status"])).is_some());
+        assert_eq!(
+            command_mode_refusal(&args(&["--workflow", "run.yml", "status"])),
+            None
+        );
+        assert_eq!(
+            command_mode_refusal(&args(&["--workflow", "run.yml", "pause"])),
+            None
+        );
+        let refusal =
+            command_mode_refusal(&args(&["--workflow", "run.yml", "--dry-run", "status"]))
+                .expect("two execution modes must be refused");
+        assert!(refusal.contains("cannot be combined"));
+    }
+
+    #[test]
+    fn load_workflow_resolves_workspaces_relative_to_the_yaml_file() {
+        let root = tempdir().expect("root");
+        fs::create_dir(root.path().join("repo")).expect("workspace");
+        let path = root.path().join("workflow.yml");
+        fs::write(
+            &path,
+            r#"orangu:
+  version: 1
+  jobs:
+    - job: repo
+      workspace: repo
+  main:
+    - command: /status
+"#,
+        )
+        .expect("workflow");
+
+        let plan = load_workflow(&path).expect("valid workflow");
+        assert_eq!(
+            plan.jobs[0].workspace,
+            root.path().join("repo").canonicalize().expect("canonical")
+        );
+    }
+
+    #[test]
+    fn load_workflow_rejects_all_invalid_slash_commands_before_execution() {
+        let root = tempdir().expect("root");
+        for workspace in ["one", "two"] {
+            fs::create_dir(root.path().join(workspace)).expect("workspace");
+        }
+        let path = root.path().join("workflow.yml");
+        fs::write(
+            &path,
+            r#"orangu:
+  version: 1
+  jobs:
+    - job: one
+      workspace: one
+    - job: two
+      workspace: two
+  main:
+    - command: /not-a-command
+    - command: /review
+    - command: /shell
+    - command: /export console
+"#,
+        )
+        .expect("workflow");
+
+        let error = format!(
+            "{:#}",
+            load_workflow(&path).expect_err("commands must be rejected")
+        );
+        assert!(error.contains("job 'one' step 1"), "{error}");
+        assert!(error.contains("job 'one' step 2"), "{error}");
+        assert!(error.contains("job 'one' step 3"), "{error}");
+        assert!(error.contains("job 'one' step 4"), "{error}");
+        assert!(error.contains("job 'two' step 1"), "{error}");
+        assert!(error.contains("job 'two' step 2"), "{error}");
+        assert!(error.contains("job 'two' step 3"), "{error}");
+        assert!(error.contains("job 'two' step 4"), "{error}");
+    }
+
+    #[test]
+    fn load_workflow_accepts_workspace_skills_and_plain_prompts() {
+        let root = tempdir().expect("root");
+        let workspace = root.path().join("repo");
+        let skill_dir = workspace.join(".orangu/skills/code-review");
+        fs::create_dir_all(&skill_dir).expect("skill directory");
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: code-review\ndescription: Review code\n---\nReview $ARGUMENTS\n",
+        )
+        .expect("skill");
+        let path = root.path().join("workflow.yml");
+        fs::write(
+            &path,
+            r#"orangu:
+  version: 1
+  jobs:
+    - job: repo
+      workspace: repo
+  main:
+    - command: /code-review auth
+    - command: Explain the result
+"#,
+        )
+        .expect("workflow");
+
+        load_workflow(&path).expect("skill and prompt should validate");
     }
 
     #[test]

--- a/src/bin/orangu/oneshot.rs
+++ b/src/bin/orangu/oneshot.rs
@@ -38,16 +38,18 @@ use std::time::{Duration, Instant};
 use anyhow::{Result, anyhow};
 
 use crate::commands::{
-    CommandContext, CommandOutcome, CommandState, ExportTarget, LocalCommand,
+    CommandContext, CommandOutcome, CommandState, ExportTarget, LocalCommand, McpSubcommand,
     current_terminal_width, parse_local_command, system_prompt,
 };
 use crate::dispatch::{handle_command, run_duplicates_scan};
 use crate::export;
 use crate::git::{Forge, ReviewReports, fetch_pull_request_details};
-use crate::models::{detect_embeddings_server, is_active_connection_a_coordinator};
+use crate::models::{
+    coordinator_role_profile, detect_embeddings_server, is_active_connection_a_coordinator,
+};
 use crate::stats::UsageStats;
 use orangu::{
-    config::ClientAppConfiguration,
+    config::{ClientAppConfiguration, LlmConfiguration},
     llm::{StreamMetrics, normalized_openai_endpoint},
     session::ChatSession,
     skills::SkillRegistry,
@@ -61,8 +63,26 @@ pub(crate) struct OneshotContext {
     pub(crate) config: ClientAppConfiguration,
     pub(crate) config_path: PathBuf,
     pub(crate) workspace: PathBuf,
+    /// Optional workflow role. A coordinator receives the role name directly;
+    /// a plain setup uses the first server configured for that role.
+    pub(crate) role: Option<String>,
     /// `-q`: print nothing at all, and let the exit code carry the result.
     pub(crate) quiet: bool,
+}
+
+/// A reusable one-shot environment. Ordinary `-p` creates one for its single
+/// input; a workflow keeps one per job so natural-language steps share the
+/// same conversation and MCP/tool connections.
+pub(crate) struct OneshotSession {
+    config: ClientAppConfiguration,
+    config_path: PathBuf,
+    workspace: PathBuf,
+    quiet: bool,
+    server: String,
+    profile: LlmConfiguration,
+    tools: ToolExecutor,
+    skills: SkillRegistry,
+    session: ChatSession,
 }
 
 /// What the `-p` text turned out to be.
@@ -122,119 +142,168 @@ impl Console {
 }
 
 pub(crate) async fn run_prompt(prompt: &str, context: OneshotContext) -> Result<()> {
-    let OneshotContext {
-        config,
-        config_path,
-        workspace,
-        quiet,
-    } = context;
-    let console = Console { quiet };
+    let mut session = OneshotSession::new(context).await?;
+    session.run(prompt).await
+}
 
-    let server = config.default_server.clone();
-    let profile = config
-        .llms
-        .get(&server)
-        .ok_or_else(|| anyhow!("missing configured server {server}"))?;
+impl OneshotSession {
+    pub(crate) async fn new(context: OneshotContext) -> Result<Self> {
+        let OneshotContext {
+            config,
+            config_path,
+            workspace,
+            role,
+            quiet,
+        } = context;
+        let console = Console { quiet };
 
-    let (mcp, mcp_warnings) =
-        orangu::mcp::McpManager::connect_all(&config.mcp_servers, &workspace).await?;
-    for warning in mcp_warnings {
-        console.note(&format!("Warning: {warning}"));
-    }
-    let tools = orangu::tools::ToolExecutor::with_config(
-        &workspace,
-        config.compression,
-        config.auto_downsample_lines,
-        config.diff_file_cap,
-        None,
-    )
-    .with_mcp(mcp.clone());
-    let skills = orangu::skills::SkillRegistry::discover(&workspace);
-
-    // Anything orangu answers on its own is answered here, before a single byte
-    // goes to the server.
-    let prompt = match run_local_command(
-        prompt,
-        LocalRun {
-            config: &config,
-            config_path: &config_path,
-            workspace: &workspace,
-            server: &server,
-            tools: &tools,
-            skills: &skills,
-            console,
-        },
-    )
-    .await?
-    {
-        Resolution::Handled => return Ok(()),
-        Resolution::Prompt(text) => text,
-    };
-    let prompt = prompt.as_str();
-
-    // The same system prompt the interactive client builds for a tab.
-    let mut system = system_prompt(profile, None).to_string();
-    let index = skills.system_prompt_index();
-    if !index.is_empty() {
-        system.push_str("\n\n");
-        system.push_str(&index);
-    }
-    system.push_str(&orangu::config::load_agents_instructions(&workspace));
-    if !mcp.instructions().is_empty() {
-        system.push_str("\n\n");
-        system.push_str(&mcp.instructions());
-    }
-
-    let definitions = tools.definitions();
-    let tools_bytes = serde_json::to_string(&definitions).map_or(0, |json| json.len());
-    console.note(&format!(
-        "server {server} ({}) model {} — workspace {}",
-        profile.endpoint,
-        profile.model,
-        workspace.display()
-    ));
-    console.note(&format!(
-        "sending {} chars of system prompt and {} tool definitions ({tools_bytes} chars)",
-        system.chars().count(),
-        definitions.len(),
-    ));
-
-    let mut session = ChatSession::new(&system);
-    let metrics = Arc::new(Mutex::new(StreamMetrics::default()));
-    let collected = Arc::clone(&metrics);
-    let started = Instant::now();
-    let mut first_delta: Option<std::time::Duration> = None;
-
-    let result = session
-        .prompt(
-            prompt,
-            profile,
-            &tools,
-            |delta| {
-                if first_delta.is_none() {
-                    first_delta = Some(started.elapsed());
+        let server = role
+            .as_deref()
+            .map(|role| config.find_server_for_role(role))
+            .unwrap_or_else(|| config.default_server.clone());
+        let configured_profile = config
+            .llms
+            .get(&server)
+            .ok_or_else(|| anyhow!("missing configured server {server}"))?
+            .clone();
+        let profile = match role.as_deref() {
+            Some(role) => {
+                let endpoint = normalized_openai_endpoint(&configured_profile.endpoint);
+                let http_client = reqwest::Client::builder()
+                    .timeout(Duration::from_secs(3))
+                    .build()?;
+                if is_active_connection_a_coordinator(
+                    &http_client,
+                    &config,
+                    &server,
+                    Some(&endpoint),
+                )
+                .await
+                {
+                    coordinator_role_profile(&configured_profile, &endpoint, role)
+                } else {
+                    configured_profile
                 }
-                console.delta(delta);
-            },
-            move |update| {
-                if let Ok(mut state) = collected.lock() {
-                    state.merge(update);
-                }
-            },
-            |_running| {},
-            |tool_call| {
-                console.note(&format!("[tool] {}", tool_call.function.name));
-            },
-            |_| false,
+            }
+            None => configured_profile,
+        };
+
+        let (mcp, mcp_warnings) =
+            orangu::mcp::McpManager::connect_all(&config.mcp_servers, &workspace).await?;
+        for warning in mcp_warnings {
+            console.note(&format!("Warning: {warning}"));
+        }
+        let tools = orangu::tools::ToolExecutor::with_config(
+            &workspace,
+            config.compression,
+            config.auto_downsample_lines,
+            config.diff_file_cap,
+            None,
         )
-        .await;
+        .with_mcp(mcp.clone());
+        let skills = orangu::skills::SkillRegistry::discover(&workspace);
 
-    console.delta("\n");
-    let elapsed = started.elapsed();
-    let metrics = metrics.lock().ok().map(|state| state.clone());
-    report_timings(console, elapsed, first_delta, metrics.as_ref());
+        // The same system prompt the interactive client builds for a tab.
+        let mut system = system_prompt(&profile, None).to_string();
+        let index = skills.system_prompt_index();
+        if !index.is_empty() {
+            system.push_str("\n\n");
+            system.push_str(&index);
+        }
+        system.push_str(&orangu::config::load_agents_instructions(&workspace));
+        if !mcp.instructions().is_empty() {
+            system.push_str("\n\n");
+            system.push_str(&mcp.instructions());
+        }
 
-    result.map(|_| ())
+        let definitions = tools.definitions();
+        let tools_bytes = serde_json::to_string(&definitions).map_or(0, |json| json.len());
+        console.note(&format!(
+            "server {server} ({}) model {} — workspace {}",
+            profile.endpoint,
+            profile.model,
+            workspace.display()
+        ));
+        console.note(&format!(
+            "sending {} chars of system prompt and {} tool definitions ({tools_bytes} chars)",
+            system.chars().count(),
+            definitions.len(),
+        ));
+
+        Ok(Self {
+            config,
+            config_path,
+            workspace,
+            quiet,
+            server,
+            profile,
+            tools,
+            skills,
+            session: ChatSession::new(&system),
+        })
+    }
+
+    pub(crate) async fn run(&mut self, input: &str) -> Result<()> {
+        let console = Console { quiet: self.quiet };
+
+        // Anything orangu answers on its own is answered here, before a single
+        // byte goes to the server.
+        let prompt = match run_local_command(
+            input,
+            LocalRun {
+                config: &self.config,
+                config_path: &self.config_path,
+                workspace: &self.workspace,
+                server: &self.server,
+                profile: &self.profile,
+                tools: &self.tools,
+                skills: &self.skills,
+                console,
+            },
+        )
+        .await?
+        {
+            Resolution::Handled => return Ok(()),
+            Resolution::Prompt(text) => text,
+        };
+
+        let metrics = Arc::new(Mutex::new(StreamMetrics::default()));
+        let collected = Arc::clone(&metrics);
+        let started = Instant::now();
+        let mut first_delta: Option<std::time::Duration> = None;
+
+        let result = self
+            .session
+            .prompt(
+                &prompt,
+                &self.profile,
+                &self.tools,
+                |delta| {
+                    if first_delta.is_none() {
+                        first_delta = Some(started.elapsed());
+                    }
+                    console.delta(delta);
+                },
+                move |update| {
+                    if let Ok(mut state) = collected.lock() {
+                        state.merge(update);
+                    }
+                },
+                |_running| {},
+                |tool_call| {
+                    console.note(&format!("[tool] {}", tool_call.function.name));
+                },
+                |_| false,
+            )
+            .await;
+
+        console.delta("\n");
+        let elapsed = started.elapsed();
+        let metrics = metrics.lock().ok().map(|state| state.clone());
+        report_timings(console, elapsed, first_delta, metrics.as_ref());
+
+        result.map(|_| ())
+    }
 }
 
 /// What the local-command path needs that the run loop would normally hold in
@@ -245,6 +314,7 @@ struct LocalRun<'a> {
     workspace: &'a Path,
     /// The configured server section the one-shot runs against.
     server: &'a str,
+    profile: &'a LlmConfiguration,
     tools: &'a ToolExecutor,
     skills: &'a SkillRegistry,
     console: Console,
@@ -253,11 +323,7 @@ struct LocalRun<'a> {
 /// Offer the `-p` text to the interactive dispatcher and, when it is a command,
 /// run it here. Returns the text to send to the model when it is not.
 async fn run_local_command(input: &str, run: LocalRun<'_>) -> Result<Resolution> {
-    let profile = run
-        .config
-        .llms
-        .get(run.server)
-        .ok_or_else(|| anyhow!("missing configured server {}", run.server))?;
+    let profile = run.profile;
 
     if let Some(command) = parse_local_command(input)
         && let Some(reason) = session_only_reason(&command)
@@ -353,7 +419,7 @@ fn absent_session_dir() -> PathBuf {
 }
 
 /// Commands whose whole effect is on the running session — the connection, the
-/// active server or model, the theme, the verbosity. A one-shot exits the
+/// active server or model, the theme, the prompt mode, or the verbosity. A one-shot exits the
 /// moment the command is done, so running them would change nothing anyone
 /// could see; say that instead of reporting a silent success.
 fn session_only_reason(command: &LocalCommand<'_>) -> Option<&'static str> {
@@ -377,11 +443,110 @@ fn session_only_reason(command: &LocalCommand<'_>) -> Option<&'static str> {
             "only changes the running session's licence, which -p does not keep; \
              the workspace's own licence is what a one-shot writes",
         ),
-        LocalCommand::SetVerbosity(_) => {
+        LocalCommand::SetVerbosity(_) | LocalCommand::Mode(_) => {
             Some("only changes the running session's system prompt, which -p does not keep")
         }
         _ => None,
     }
+}
+
+/// Reject an explicit workflow slash command when its failure can be known
+/// before configuration is loaded or a job starts. Unknown names may still be
+/// workspace skills, so discovery is part of this otherwise static check.
+pub(crate) fn validate_workflow_input(input: &str, skills: &SkillRegistry) -> Result<()> {
+    let input = input.trim();
+    if !input.starts_with('/') {
+        return Ok(());
+    }
+
+    let Some(command) = parse_local_command(input) else {
+        let name = input[1..]
+            .split_once(char::is_whitespace)
+            .map_or(&input[1..], |(name, _)| name);
+        if !name.is_empty() && skills.find(name).is_some() {
+            return Ok(());
+        }
+        return Err(anyhow!(
+            "unknown command or workspace skill '{input}'; use /help to see available commands"
+        ));
+    };
+
+    if let Some(reason) = session_only_reason(&command) {
+        return Err(anyhow!("'{input}' {reason}"));
+    }
+    if terminal_only(&command) {
+        return Err(anyhow!(
+            "'{input}' needs the terminal interface and cannot run in a workflow"
+        ));
+    }
+    if invalid_static_arguments(&command) {
+        return Err(anyhow!("'{input}' has missing or invalid arguments"));
+    }
+    if matches!(
+        command,
+        LocalCommand::Export(
+            ExportTarget::Console | ExportTarget::Review | ExportTarget::AutoReview
+        )
+    ) {
+        return Err(anyhow!(
+            "'{input}' exports interactive session state that a workflow does not have"
+        ));
+    }
+
+    Ok(())
+}
+
+fn terminal_only(command: &LocalCommand<'_>) -> bool {
+    matches!(
+        command,
+        LocalCommand::Restart
+            | LocalCommand::Review
+            | LocalCommand::AutoReview(_, _, _)
+            | LocalCommand::Manual
+            | LocalCommand::Clear
+            | LocalCommand::Copy
+            | LocalCommand::Quit
+            | LocalCommand::Session(Some(_))
+            | LocalCommand::Workspace(Some(_))
+            | LocalCommand::CreateWorkspace(_)
+            | LocalCommand::DeleteWorkspace
+            | LocalCommand::PendingList
+            | LocalCommand::PendingDelete(Some(_))
+    )
+}
+
+fn invalid_static_arguments(command: &LocalCommand<'_>) -> bool {
+    matches!(
+        command,
+        LocalCommand::ShowFile(path) if path.trim().is_empty()
+    ) || matches!(
+        command,
+        LocalCommand::OpenFile(path) if path.trim().is_empty()
+    ) || matches!(
+        command,
+        LocalCommand::Grep(None)
+            | LocalCommand::Search(None)
+            | LocalCommand::Pull(None)
+            | LocalCommand::Comment(None)
+            | LocalCommand::Close(None)
+            | LocalCommand::Issue(None)
+            | LocalCommand::GetComments(None)
+            | LocalCommand::Merge(None)
+            | LocalCommand::Restore(None)
+            | LocalCommand::CreateFile(None)
+            | LocalCommand::DeleteFile(None)
+            | LocalCommand::MoveFile(None)
+            | LocalCommand::CreateDirectory(None)
+            | LocalCommand::MoveDirectory(None)
+            | LocalCommand::DeleteDirectory(None)
+            | LocalCommand::CherryPick(None)
+            | LocalCommand::Commit(None)
+            | LocalCommand::Amend(None)
+            | LocalCommand::Prune(None)
+            | LocalCommand::Shell(None)
+            | LocalCommand::PendingDelete(None)
+            | LocalCommand::Mcp(McpSubcommand::Usage)
+    )
 }
 
 /// Carry out what the dispatcher decided, printing to stdout instead of to the
@@ -543,6 +708,8 @@ mod tests {
             "/license MIT",
             "/verbosity terse",
             "/verbosity",
+            "/developer",
+            "/committer",
         ] {
             assert!(reason_for(input).is_some(), "{input} should be refused");
         }

--- a/src/bin/orangu/shell.rs
+++ b/src/bin/orangu/shell.rs
@@ -29,7 +29,13 @@ _orangu() {
 
     case "$prev" in
         -c|--config)
-            # Configuration file (orangu.conf)
+            # Configuration file (orangu.conf).
+            COMPREPLY=( $(compgen -f -- "$cur") )
+            compopt -o filenames 2>/dev/null
+            return 0
+            ;;
+        --workflow)
+            # YAML workflow file.
             COMPREPLY=( $(compgen -f -- "$cur") )
             compopt -o filenames 2>/dev/null
             return 0
@@ -66,9 +72,10 @@ _orangu() {
 
     if [[ "$cur" == -* ]]; then
         COMPREPLY=( $(compgen -W \
-            "-c --config -t --theme -w --workspace -r --resume -a --all -p --prompt -q --quiet -l --list -i --init -s --shell-completions -h --help" -- "$cur") )
+            "-c --config -t --theme -w --workspace -r --resume -a --all -p --prompt --workflow --dry-run -q --quiet -l --list -i --init -s --shell-completions -h --help" -- "$cur") )
         return 0
     fi
+    COMPREPLY=( $(compgen -W "status pause resume clear" -- "$cur") )
 }
 
 complete -F _orangu orangu
@@ -118,11 +125,14 @@ _orangu() {
         '(-r --resume)'{-r,--resume}'[Resume a session by UUID]:session uuid:_orangu_sessions' \
         '(-a --all)'{-a,--all}'[Reopen the workspace tabs from the previous run]' \
         '(-p --prompt)'{-p,--prompt}'[Run one prompt or command, print the result and exit]:prompt:' \
+        '--workflow[Validate and execute every job in a YAML workflow]:workflow file:_files' \
+        '--dry-run[Validate the workflow without executing it]' \
         '(-q --quiet)'{-q,--quiet}'[Print nothing on success; the exit code is the result]' \
         '(-l --list)'{-l,--list}'[List all stored sessions as a table and exit]' \
         '(-i --init)'{-i,--init}'[Interactively create ~/.orangu/orangu.conf and exit]' \
         '(-s --shell-completions)'{-s,--shell-completions}'[Print shell completion script for the detected shell and exit]' \
-        '(-h --help)'{-h,--help}'[Print help]'
+        '(-h --help)'{-h,--help}'[Print help]' \
+        '1:command:(status pause resume clear)'
 }
 
 _orangu "$@"
@@ -158,11 +168,14 @@ complete -c orangu -s w -l workspace         -x -a '(__orangu_workspaces)' -d 'W
 complete -c orangu -s r -l resume            -x -a '(__orangu_sessions)'   -d 'Resume a session by UUID'
 complete -c orangu -s a -l all                                            -d 'Reopen the workspace tabs from the previous run'
 complete -c orangu -s p -l prompt            -x                           -d 'Run one prompt or command, print the result and exit'
+complete -c orangu      -l workflow        -r -a '(__fish_complete_path)' -d 'Validate and execute every job in a YAML workflow'
+complete -c orangu      -l dry-run                                        -d 'Validate the workflow without executing it'
 complete -c orangu -s q -l quiet                                          -d 'Print nothing on success; the exit code is the result'
 complete -c orangu -s l -l list                                           -d 'List all stored sessions as a table and exit'
 complete -c orangu -s i -l init                                           -d 'Interactively create ~/.orangu/orangu.conf and exit'
 complete -c orangu -s s -l shell-completions                              -d 'Print shell completion script for the detected shell and exit'
 complete -c orangu -s h -l help                                           -d 'Print help'
+complete -c orangu -f -a 'status pause resume clear'                      -d 'Manage the saved workflow loops'
 "#;
 
 #[cfg(test)]
@@ -231,6 +244,22 @@ mod tests {
                     script.contains(&theme),
                     "{shell} completion omits the built-in theme: {theme}"
                 );
+            }
+        }
+    }
+
+    #[test]
+    fn every_shell_completes_the_workflow_lifecycle_actions() {
+        // `loop` is a workflow-language step, not a CLI subcommand: the only
+        // positional commands are the `orangu --workflow FILE <action>`
+        // lifecycle actions.
+        for (shell, script) in [("bash", BASH), ("zsh", ZSH), ("fish", FISH)] {
+            assert!(
+                !script.contains("__orangu_using_loop") && !script.contains("--until"),
+                "{shell} completion still mentions the removed loop interface"
+            );
+            for value in ["status", "pause", "resume", "clear"] {
+                assert!(script.contains(value), "{shell} completion omits {value}");
             }
         }
     }

--- a/src/bin/orangu/workflow.rs
+++ b/src/bin/orangu/workflow.rs
@@ -1,0 +1,2649 @@
+// Copyright (C) 2026 The orangu community
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Sequential execution of a fully validated YAML workflow.
+
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+
+use anyhow::{Context, Result, anyhow};
+use orangu::{config::ClientAppConfiguration, skills::SkillRegistry};
+
+use crate::{
+    r#loop,
+    oneshot::{OneshotContext, OneshotSession, validate_workflow_input},
+};
+
+/// Check every explicit command before any job starts. Natural-language steps
+/// remain model prompts; slash commands must name either a built-in command or
+/// a skill visible from that job's workspace, and must be runnable headlessly.
+pub(crate) fn validate(plan: &WorkflowPlan) -> Result<()> {
+    let mut failures = Vec::new();
+
+    for job in &plan.jobs {
+        let skills = SkillRegistry::discover(&job.workspace);
+        let mut commands = Vec::new();
+        for (name, body) in &job.functions {
+            collect_commands(body, &format!("function '{name}'"), &mut commands);
+        }
+        collect_commands(&job.steps, "", &mut commands);
+        for (location, command) in commands {
+            if let Err(error) = validate_workflow_input(command, &skills) {
+                failures.push(format!("job '{}' {location}: {error}", job.name));
+            }
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "workflow command validation failed:\n- {}",
+            failures.join("\n- ")
+        ))
+    }
+}
+
+/// Every runnable command in a step tree: plain commands plus the `if` and
+/// `while` conditions that execute at runtime. Locations read like
+/// `step 2 then 1` so failures point at the offending nested step.
+fn collect_commands<'a>(
+    steps: &'a [WorkflowStep],
+    scope: &str,
+    output: &mut Vec<(String, &'a String)>,
+) {
+    for (index, step) in steps.iter().enumerate() {
+        let here = if scope.is_empty() {
+            format!("step {}", index + 1)
+        } else {
+            format!("{scope} step {}", index + 1)
+        };
+        match step {
+            WorkflowStep::Command(command) => output.push((here, command)),
+            WorkflowStep::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                output.push((format!("{here} condition"), condition));
+                collect_commands(then_branch, &format!("{here} then"), output);
+                collect_commands(else_branch, &format!("{here} else"), output);
+            }
+            WorkflowStep::For { body, .. } => {
+                collect_commands(body, &format!("{here} for"), output);
+            }
+            WorkflowStep::While {
+                condition, body, ..
+            } => {
+                output.push((format!("{here} condition"), condition));
+                collect_commands(body, &format!("{here} while"), output);
+            }
+            WorkflowStep::Call(_)
+            | WorkflowStep::Approved(_)
+            | WorkflowStep::Loop(_)
+            | WorkflowStep::Break
+            | WorkflowStep::Return
+            | WorkflowStep::Label(_)
+            | WorkflowStep::Goto(_) => {}
+        }
+    }
+}
+
+/// Run jobs and their steps in declaration order. A job owns one session,
+/// so all model prompts in that job share conversation history. Control-flow
+/// steps interpret at execution time: a condition is an ordinary workflow
+/// command whose success means true, `for` iterates its finite items, and
+/// `while` re-checks its condition up to its validated `max_turns`.
+pub(crate) async fn run(
+    plan: WorkflowPlan,
+    config: ClientAppConfiguration,
+    config_path: PathBuf,
+    quiet: bool,
+) -> Result<()> {
+    for job in plan.jobs {
+        if !quiet {
+            eprintln!(
+                "workflow: job '{}' (role {}, workspace {})",
+                job.name,
+                job.role,
+                job.workspace.display()
+            );
+        }
+        let mut runtime = JobRuntime {
+            job_name: job.name.clone(),
+            workspace: job.workspace.clone(),
+            role: job.role.clone(),
+            functions: job.functions,
+            config: config.clone(),
+            config_path: config_path.clone(),
+            quiet,
+            session: None,
+        };
+        let steps = job.steps;
+        match run_block(&steps, &mut runtime).await? {
+            Signal::Continue | Signal::Return => {}
+            Signal::Break => {
+                return Err(anyhow!(
+                    "workflow job '{}' has break outside a for or while loop",
+                    runtime.job_name
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// What a step list evaluates to: keep going, or unwind to a loop (`Break`),
+/// a caller (`Return`), or a same-list label (`Goto`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Signal {
+    Continue,
+    Break,
+    Return,
+}
+
+struct JobRuntime {
+    job_name: String,
+    workspace: PathBuf,
+    role: String,
+    functions: std::collections::BTreeMap<String, Vec<WorkflowStep>>,
+    config: ClientAppConfiguration,
+    config_path: PathBuf,
+    quiet: bool,
+    session: Option<OneshotSession>,
+}
+
+impl JobRuntime {
+    async fn session(&mut self) -> Result<&mut OneshotSession> {
+        if self.session.is_none() {
+            self.session = Some(
+                OneshotSession::new(OneshotContext {
+                    config: self.config.clone(),
+                    config_path: self.config_path.clone(),
+                    workspace: self.workspace.clone(),
+                    role: Some(self.role.clone()),
+                    quiet: self.quiet,
+                })
+                .await
+                .with_context(|| format!("workflow job '{}' could not start", self.job_name))?,
+            );
+        }
+        Ok(self
+            .session
+            .as_mut()
+            .expect("workflow session was initialized"))
+    }
+}
+
+/// Interpret one step list. Labels only address this list: a `goto` jumps to
+/// a label from the same steps, so control never implicitly enters a nested
+/// block. `Break` and `Return` propagate to their loop or caller.
+fn run_block<'a>(
+    steps: &'a [WorkflowStep],
+    runtime: &'a mut JobRuntime,
+) -> Pin<Box<dyn Future<Output = Result<Signal>> + 'a>> {
+    Box::pin(run_block_inner(steps, runtime))
+}
+
+async fn run_block_inner(steps: &[WorkflowStep], runtime: &mut JobRuntime) -> Result<Signal> {
+    let mut labels = std::collections::HashMap::new();
+    for (index, step) in steps.iter().enumerate() {
+        if let WorkflowStep::Label(name) = step {
+            labels.insert(name.clone(), index);
+        }
+    }
+    let mut pc = 0;
+    while pc < steps.len() {
+        let step = &steps[pc];
+        match step {
+            WorkflowStep::Approved(path) => {
+                if !runtime.quiet {
+                    eprintln!("workflow: approved {}", path.display());
+                }
+            }
+            WorkflowStep::Label(_) => {}
+            WorkflowStep::Goto(label) => {
+                pc = *labels.get(label).with_context(|| {
+                    format!(
+                        "workflow job '{}' jumps to unknown label '{label}'",
+                        runtime.job_name
+                    )
+                })?;
+                continue;
+            }
+            WorkflowStep::Break => return Ok(Signal::Break),
+            WorkflowStep::Return => return Ok(Signal::Return),
+            WorkflowStep::Command(command) => {
+                if !runtime.quiet {
+                    eprintln!("workflow: job '{}': {command}", runtime.job_name);
+                }
+                let job = runtime.job_name.clone();
+                runtime
+                    .session()
+                    .await?
+                    .run(command)
+                    .await
+                    .with_context(|| format!("workflow job '{job}' failed at: {command}"))?;
+            }
+            WorkflowStep::Call(name) => {
+                if !runtime.quiet {
+                    eprintln!("workflow: job '{}': call {name}", runtime.job_name);
+                }
+                let body = runtime.functions.get(name).cloned().with_context(|| {
+                    format!(
+                        "workflow job '{}' calls unknown function '{name}'",
+                        runtime.job_name
+                    )
+                })?;
+                match run_block(&body, runtime).await? {
+                    Signal::Continue | Signal::Return => {}
+                    Signal::Break => return Ok(Signal::Break),
+                }
+            }
+            WorkflowStep::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                let branch = if eval_condition(condition, runtime).await? {
+                    then_branch
+                } else {
+                    else_branch
+                };
+                match run_block(branch, runtime).await? {
+                    Signal::Continue => {}
+                    Signal::Break => return Ok(Signal::Break),
+                    Signal::Return => return Ok(Signal::Return),
+                }
+            }
+            WorkflowStep::For { var, items, body } => {
+                for item in items {
+                    let expanded = body
+                        .iter()
+                        .map(|step| substitute(step, var, item))
+                        .collect::<Vec<_>>();
+                    match run_block(&expanded, runtime).await? {
+                        Signal::Continue => {}
+                        Signal::Break => break,
+                        Signal::Return => return Ok(Signal::Return),
+                    }
+                }
+            }
+            WorkflowStep::While {
+                condition,
+                max_turns,
+                body,
+            } => {
+                for _ in 0..*max_turns {
+                    if !eval_condition(condition, runtime).await? {
+                        break;
+                    }
+                    match run_block(body, runtime).await? {
+                        Signal::Continue => {}
+                        Signal::Break => break,
+                        Signal::Return => return Ok(Signal::Return),
+                    }
+                }
+            }
+            WorkflowStep::Loop(spec) => {
+                if !runtime.quiet {
+                    eprintln!("workflow: job '{}': code-and-review loop", runtime.job_name);
+                }
+                let job = runtime.job_name.clone();
+                r#loop::run_workflow(
+                    spec.clone(),
+                    r#loop::LoopRunContext {
+                        config: runtime.config.clone(),
+                        workspace: runtime.workspace.clone(),
+                        role: Some(runtime.role.clone()),
+                        quiet: runtime.quiet,
+                    },
+                )
+                .await
+                .with_context(|| format!("workflow job '{job}' loop failed"))?;
+            }
+        }
+        pc += 1;
+    }
+    Ok(Signal::Continue)
+}
+
+/// Run a condition command in the job session. Success means true; failure
+/// means false and selects the other branch instead of failing the job.
+async fn eval_condition(condition: &str, runtime: &mut JobRuntime) -> Result<bool> {
+    if !runtime.quiet {
+        eprintln!("workflow: job '{}': if {condition}", runtime.job_name);
+    }
+    let outcome = runtime.session().await?.run(condition).await;
+    Ok(outcome.is_ok())
+}
+
+/// Substitute one `for` iteration value into a compiled step. Only command
+/// text, conditions, and loop parameters can carry `${var}`: approvals
+/// resolve at validation time and never contain it.
+fn substitute(step: &WorkflowStep, var: &str, value: &str) -> WorkflowStep {
+    let placeholder = format!("${{{var}}}");
+    let fill = |text: &String| text.replace(&placeholder, value);
+    match step {
+        WorkflowStep::Command(command) => WorkflowStep::Command(fill(command)),
+        WorkflowStep::Approved(path) => WorkflowStep::Approved(path.clone()),
+        WorkflowStep::Loop(spec) => WorkflowStep::Loop(WorkflowLoop {
+            objective: fill(&spec.objective),
+            stop: match &spec.stop {
+                WorkflowLoopStop::Turns(count) => WorkflowLoopStop::Turns(*count),
+                WorkflowLoopStop::Time(duration) => WorkflowLoopStop::Time(*duration),
+                WorkflowLoopStop::Goal(condition) => WorkflowLoopStop::Goal(fill(condition)),
+            },
+            checks: spec.checks.iter().map(fill).collect(),
+            rubric: spec.rubric.iter().map(fill).collect(),
+        }),
+        WorkflowStep::Call(name) => WorkflowStep::Call(name.clone()),
+        WorkflowStep::If {
+            condition,
+            then_branch,
+            else_branch,
+        } => WorkflowStep::If {
+            condition: fill(condition),
+            then_branch: then_branch
+                .iter()
+                .map(|step| substitute(step, var, value))
+                .collect(),
+            else_branch: else_branch
+                .iter()
+                .map(|step| substitute(step, var, value))
+                .collect(),
+        },
+        WorkflowStep::For {
+            var: inner,
+            items,
+            body,
+        } => WorkflowStep::For {
+            var: inner.clone(),
+            items: items.iter().map(fill).collect(),
+            body: body
+                .iter()
+                .map(|step| substitute(step, var, value))
+                .collect(),
+        },
+        WorkflowStep::While {
+            condition,
+            max_turns,
+            body,
+        } => WorkflowStep::While {
+            condition: fill(condition),
+            max_turns: *max_turns,
+            body: body
+                .iter()
+                .map(|step| substitute(step, var, value))
+                .collect(),
+        },
+        WorkflowStep::Break => WorkflowStep::Break,
+        WorkflowStep::Return => WorkflowStep::Return,
+        WorkflowStep::Label(name) => WorkflowStep::Label(name.clone()),
+        WorkflowStep::Goto(label) => WorkflowStep::Goto(label.clone()),
+    }
+}
+
+/// Apply a loop lifecycle action to every job described by the workflow.
+pub(crate) async fn manage(
+    plan: WorkflowPlan,
+    config: ClientAppConfiguration,
+    quiet: bool,
+    action: &str,
+) -> Result<()> {
+    for job in plan.jobs {
+        if !quiet {
+            eprintln!(
+                "workflow: {} job '{}' (workspace {})",
+                action,
+                job.name,
+                job.workspace.display()
+            );
+        }
+        r#loop::workflow_action(
+            action,
+            r#loop::LoopRunContext {
+                config: config.clone(),
+                workspace: job.workspace,
+                role: Some(job.role),
+                quiet,
+            },
+        )
+        .await
+        .with_context(|| format!("workflow job '{}' {} failed", job.name, action))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+    };
+    use tempfile::NamedTempFile;
+
+    fn serve_non_coordinator(
+        listener: TcpListener,
+        requests: usize,
+    ) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || {
+            for _ in 0..requests {
+                let (mut stream, _) = listener.accept().expect("accept coordinator probe");
+                let mut request = Vec::new();
+                let mut buffer = [0u8; 1024];
+                loop {
+                    let read = stream.read(&mut buffer).expect("read coordinator probe");
+                    assert!(read > 0, "coordinator probe ended before its headers");
+                    request.extend_from_slice(&buffer[..read]);
+                    if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                assert!(
+                    String::from_utf8_lossy(&request).contains("/v1/coordinator"),
+                    "unexpected request: {}",
+                    String::from_utf8_lossy(&request)
+                );
+                stream
+                    .write_all(
+                        b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                    )
+                    .expect("write coordinator response");
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn complete_multi_job_workflow_runs_functions_in_order() {
+        let root = tempfile::tempdir().expect("root");
+        let output = root.path().join("output");
+        std::fs::create_dir(&output).expect("output directory");
+        for workspace in ["one", "two"] {
+            std::fs::create_dir(root.path().join(workspace)).expect("workspace");
+        }
+
+        let yaml = format!(
+            r#"orangu:
+  version: 1
+  variables:
+    upstream: >-
+      {}
+  jobs:
+    - job: one
+      workspace: one
+    - job: two
+      workspace: two
+  functions:
+    create_result:
+      - command: /create_file ${{job}}.txt containing created-${{job}}
+    move_result:
+      - command: /shell mv "${{job}}.txt" "${{upstream}}/${{job}}.txt"
+  main:
+    - approved: ${{upstream}}
+    - call: create_result
+    - call: move_result
+"#,
+            output.display()
+        );
+        let plan = compile(&yaml, root.path()).expect("compile workflow");
+        validate(&plan).expect("preflight workflow");
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake server");
+        let endpoint = format!("http://{}/v1", listener.local_addr().expect("address"));
+        let server = serve_non_coordinator(listener, plan.jobs.len());
+        let config_file = NamedTempFile::new().expect("config");
+        std::fs::write(
+            config_file.path(),
+            format!(
+                "[orangu]\nserver = test\nmodel = test-model\ntimeout = 5\n\n[test]\nrole = all\nendpoint = {endpoint}\nmodel = test-model\n"
+            ),
+        )
+        .expect("write config");
+        let config =
+            orangu::config::load_client_configuration(config_file.path()).expect("load config");
+
+        run(plan, config, config_file.path().to_path_buf(), true)
+            .await
+            .expect("run workflow");
+        server.join().expect("fake server thread");
+
+        for job in ["one", "two"] {
+            let result = output.join(format!("{job}.txt"));
+            assert!(result.is_file(), "{} was not collected", result.display());
+            let content = std::fs::read_to_string(&result).expect("read result");
+            assert!(content.contains(&format!("created-{job}")), "{content}");
+            assert!(
+                !root.path().join(job).join(format!("{job}.txt")).exists(),
+                "source should have been moved"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn control_flow_for_if_while_break_and_goto_run_in_order() {
+        let root = tempfile::tempdir().expect("root");
+        std::fs::create_dir(root.path().join("repo")).expect("workspace");
+
+        let yaml = r#"orangu:
+  version: 1
+  jobs:
+    - job: repo
+      workspace: repo
+  functions:
+    make_pair:
+      - for:
+          var: item
+          items: [alpha, beta]
+          do:
+            - command: /create_file ${item}.txt containing ${item}
+      - return: true
+  main:
+    - call: make_pair
+    - for:
+        var: name
+        items: [first, second]
+        do:
+          - command: /create_file ${name}.txt containing ${name}
+          - break: true
+    - if:
+        condition: /shell test -f alpha.txt
+        then:
+          - command: /create_file picked.txt containing then-branch
+        else:
+          - command: /create_file picked.txt containing else-branch
+    - if:
+        condition: /shell test -f missing.txt
+        then:
+          - command: /create_file other.txt containing then-branch
+        else:
+          - command: /create_file other.txt containing else-branch
+    - while:
+        condition: /shell test ! -f stop.txt
+        max_turns: 5
+        do:
+          - command: /shell touch stop.txt
+    - goto: skip
+    - command: /create_file skipped.txt containing skipped
+    - label: skip
+    - command: /create_file reached.txt containing reached
+"#;
+        let plan = compile(yaml, root.path()).expect("compile workflow");
+        validate(&plan).expect("preflight workflow");
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake server");
+        let endpoint = format!("http://{}/v1", listener.local_addr().expect("address"));
+        let server = serve_non_coordinator(listener, plan.jobs.len());
+        let config_file = NamedTempFile::new().expect("config");
+        std::fs::write(
+            config_file.path(),
+            format!(
+                "[orangu]\nserver = test\nmodel = test-model\ntimeout = 5\n\n[test]\nrole = all\nendpoint = {endpoint}\nmodel = test-model\n"
+            ),
+        )
+        .expect("write config");
+        let config =
+            orangu::config::load_client_configuration(config_file.path()).expect("load config");
+
+        run(plan, config, config_file.path().to_path_buf(), true)
+            .await
+            .expect("run workflow");
+        server.join().expect("fake server thread");
+
+        let repo = root.path().join("repo");
+        for (file, content) in [
+            ("alpha.txt", "alpha"),
+            ("beta.txt", "beta"),
+            ("first.txt", "first"),
+            ("picked.txt", "then-branch"),
+            ("other.txt", "else-branch"),
+            ("reached.txt", "reached"),
+        ] {
+            let text = std::fs::read_to_string(repo.join(file)).expect(file);
+            assert!(text.contains(content), "{file}: {text}");
+        }
+        assert!(repo.join("stop.txt").is_file(), "while body ran once");
+        assert!(!repo.join("second.txt").exists(), "break stopped the loop");
+        assert!(!repo.join("skipped.txt").exists(), "goto skipped the step");
+    }
+}
+
+mod language {
+    // Copyright (C) 2026 The orangu community
+    //
+    // This program is free software: you can redistribute it and/or modify
+    // it under the terms of the GNU General Public License as published by
+    // the Free Software Foundation, either version 3 of the License, or
+    // (at your option) any later version.
+    //
+    // This program is distributed in the hope that it will be useful,
+    // but WITHOUT ANY WARRANTY; without even the implied warranty of
+    // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    // GNU General Public License for more details.
+    //
+    // You should have received a copy of the GNU General Public License
+    // along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+    //! Parser and whole-file validator for Orangu YAML workflows.
+    //!
+    //! A workflow is fully parsed, its variables and function calls are expanded
+    //! once per job, and every workspace and approved path is checked before the
+    //! runner can start the first (potentially long-running) command.
+
+    use serde::Deserialize;
+    use std::collections::{BTreeMap, HashMap, HashSet};
+    use std::error::Error;
+    use std::fmt;
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+
+    const KNOWN_ROLES: &[&str] = &["all", "code", "review", "explorer", "embeddings"];
+
+    /// A validated workflow, with function calls and variables expanded for each
+    /// job. The runner consumes this type rather than the raw YAML.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct WorkflowPlan {
+        pub version: u32,
+        pub jobs: Vec<WorkflowJob>,
+    }
+
+    /// One independent job in a validated workflow.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct WorkflowJob {
+        pub name: String,
+        pub workspace: PathBuf,
+        pub role: String,
+        /// The job's `main` steps. Function `call`s resolve against
+        /// `functions` at execution time so `return` and `break` behave.
+        pub steps: Vec<WorkflowStep>,
+        /// Every function compiled for this job, with that job's variables
+        /// (and `${job}`) already interpolated.
+        pub functions: BTreeMap<String, Vec<WorkflowStep>>,
+    }
+
+    /// One compiled workflow operation. Control-flow steps keep their nested
+    /// bodies: the runner interprets them at execution time, after every step
+    /// (including every branch and condition) has been validated.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum WorkflowStep {
+        /// Input for Orangu's existing command/prompt dispatcher.
+        Command(String),
+        /// Explicit workflow-language permission to pass an existing path outside
+        /// the workspace through a variable. It does not widen file-tool roots or
+        /// turn the platform shell into an operating-system sandbox.
+        Approved(PathBuf),
+        /// A bounded tool-enabled work and read-only review cycle.
+        Loop(WorkflowLoop),
+        /// Run a named function. Recursion is rejected at validation time.
+        Call(String),
+        /// Run `then_branch` when `condition` succeeds, else `else_branch`.
+        /// The condition is an ordinary workflow command: success is true.
+        If {
+            condition: String,
+            then_branch: Vec<WorkflowStep>,
+            else_branch: Vec<WorkflowStep>,
+        },
+        /// Run `body` once per item with `${var}` set to that item.
+        For {
+            var: String,
+            items: Vec<String>,
+            body: Vec<WorkflowStep>,
+        },
+        /// Re-evaluate `condition` before each turn and run `body` while it
+        /// succeeds, up to `max_turns` turns.
+        While {
+            condition: String,
+            max_turns: u32,
+            body: Vec<WorkflowStep>,
+        },
+        /// Stop the innermost enclosing `for` or `while` body.
+        Break,
+        /// Stop the current function and continue after its `call`.
+        Return,
+        /// A jump target for `goto`. Labels live in the step list that
+        /// declares them; a `goto` must name a label from the same list.
+        Label(String),
+        /// Continue execution at the same-list label with this name.
+        Goto(String),
+    }
+
+    /// A validated code-and-review loop embedded in a workflow.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct WorkflowLoop {
+        pub objective: String,
+        pub stop: WorkflowLoopStop,
+        pub checks: Vec<String>,
+        pub rubric: Vec<String>,
+    }
+
+    /// The single condition that bounds a workflow loop.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum WorkflowLoopStop {
+        Turns(u32),
+        Time(Duration),
+        Goal(String),
+    }
+
+    /// A syntax or semantic failure found before workflow execution.
+    #[derive(Debug)]
+    pub enum WorkflowError {
+        Yaml(serde_yaml::Error),
+        Validation(Vec<String>),
+    }
+
+    impl fmt::Display for WorkflowError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::Yaml(error) => write!(f, "invalid workflow YAML: {error}"),
+                Self::Validation(errors) => {
+                    writeln!(f, "workflow validation failed:")?;
+                    for error in errors {
+                        writeln!(f, "- {error}")?;
+                    }
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    impl Error for WorkflowError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            match self {
+                Self::Yaml(error) => Some(error),
+                Self::Validation(_) => None,
+            }
+        }
+    }
+
+    /// Parse and validate a workflow without executing it.
+    ///
+    /// Relative workspace paths are resolved against `base_dir`. Relative
+    /// approved paths are resolved against the job workspace. Every referenced
+    /// workspace and approved path must already exist, making this function both
+    /// the structural validator and the execution preflight.
+    pub fn compile(source: &str, base_dir: &Path) -> Result<WorkflowPlan, WorkflowError> {
+        let document: RawDocument = serde_yaml::from_str(source).map_err(WorkflowError::Yaml)?;
+        compile_document(document.orangu, base_dir)
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct RawDocument {
+        orangu: RawWorkflow,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct RawWorkflow {
+        version: u32,
+        #[serde(default)]
+        role: Option<String>,
+        #[serde(default)]
+        variables: BTreeMap<String, Scalar>,
+        #[serde(default)]
+        jobs: Vec<RawJob>,
+        #[serde(default)]
+        functions: BTreeMap<String, Vec<RawStep>>,
+        #[serde(default)]
+        main: Vec<RawStep>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct RawJob {
+        job: String,
+        workspace: String,
+        #[serde(default)]
+        role: Option<String>,
+        #[serde(default)]
+        variables: BTreeMap<String, Scalar>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct RawStep {
+        #[serde(default)]
+        command: Option<String>,
+        #[serde(default)]
+        call: Option<String>,
+        #[serde(default)]
+        approved: Option<OneOrMany>,
+        #[serde(default)]
+        r#loop: Option<RawLoop>,
+        #[serde(default, rename = "if")]
+        r#if: Option<RawIf>,
+        #[serde(default, rename = "for")]
+        r#for: Option<RawFor>,
+        #[serde(default, rename = "while")]
+        r#while: Option<RawWhile>,
+        #[serde(default, rename = "break")]
+        r#break: Option<bool>,
+        #[serde(default, rename = "return")]
+        r#return: Option<bool>,
+        #[serde(default)]
+        label: Option<String>,
+        #[serde(default)]
+        goto: Option<String>,
+    }
+
+    /// `if` runs its `then` steps when `condition` — an ordinary workflow
+    /// command — succeeds, and its `else` steps otherwise.
+    #[derive(Debug, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct RawIf {
+        condition: String,
+        then: Vec<RawStep>,
+        #[serde(default)]
+        r#else: Option<Vec<RawStep>>,
+    }
+
+    /// `for` repeats its `do` steps once per item (or once per value of a
+    /// finite `range` such as `1..3`), with `${var}` set to that value.
+    #[derive(Debug, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct RawFor {
+        var: String,
+        #[serde(default)]
+        items: Option<Vec<String>>,
+        #[serde(default)]
+        range: Option<String>,
+        #[serde(rename = "do")]
+        body: Vec<RawStep>,
+    }
+
+    /// `while` re-runs `condition` before every turn and executes `do` while
+    /// it succeeds, stopping after `max_turns` turns at the latest.
+    #[derive(Debug, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct RawWhile {
+        condition: String,
+        max_turns: u32,
+        #[serde(rename = "do")]
+        body: Vec<RawStep>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct RawLoop {
+        objective: String,
+        stop: RawLoopStop,
+        #[serde(default)]
+        review: RawLoopReview,
+    }
+
+    #[derive(Debug, Default, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct RawLoopReview {
+        #[serde(default)]
+        checks: Vec<String>,
+        #[serde(default)]
+        rubric: Vec<String>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+    enum RawLoopStop {
+        Turns { count: u32 },
+        Time { duration: String },
+        Goal { condition: String },
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+
+    impl OneOrMany {
+        fn values(&self) -> Box<dyn Iterator<Item = &str> + '_> {
+            match self {
+                Self::One(value) => Box::new(std::iter::once(value.as_str())),
+                Self::Many(values) => Box::new(values.iter().map(String::as_str)),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Deserialize)]
+    #[serde(untagged)]
+    enum Scalar {
+        String(String),
+        Integer(i64),
+        Float(f64),
+        Boolean(bool),
+    }
+
+    impl Scalar {
+        fn text(&self) -> String {
+            match self {
+                Self::String(value) => value.clone(),
+                Self::Integer(value) => value.to_string(),
+                Self::Float(value) => value.to_string(),
+                Self::Boolean(value) => value.to_string(),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum StepKind<'a> {
+        Command(&'a str),
+        Call(&'a str),
+        Approved(&'a OneOrMany),
+        Loop(&'a RawLoop),
+        If(&'a RawIf),
+        For(&'a RawFor),
+        While(&'a RawWhile),
+        Break,
+        Return,
+        Label(&'a str),
+        Goto(&'a str),
+    }
+
+    /// Upper bounds that keep every loop finite before execution starts.
+    const MAX_FOR_ITEMS: usize = 100;
+    const MAX_FOR_RANGE_SPAN: u64 = 1000;
+    const MAX_WHILE_TURNS: u32 = 1000;
+
+    fn compile_document(raw: RawWorkflow, base_dir: &Path) -> Result<WorkflowPlan, WorkflowError> {
+        let mut errors = Vec::new();
+
+        if raw.version != 1 {
+            errors.push(format!(
+                "unsupported workflow version {}; expected 1",
+                raw.version
+            ));
+        }
+        if raw.jobs.is_empty() {
+            errors.push("at least one job is required".to_string());
+        }
+        if raw.main.is_empty() {
+            errors.push("main must contain at least one step".to_string());
+        }
+
+        validate_role(
+            raw.role.as_deref().unwrap_or("all"),
+            "global role",
+            &mut errors,
+        );
+        validate_variable_names(&raw.variables, "global variables", &mut errors);
+        validate_functions(&raw.functions, &raw.main, &mut errors);
+
+        let mut names = HashSet::new();
+        for job in &raw.jobs {
+            if job.job.trim().is_empty() {
+                errors.push("job names cannot be empty".to_string());
+            } else if !names.insert(job.job.as_str()) {
+                errors.push(format!("duplicate job name '{}'", job.job));
+            }
+            validate_variable_names(
+                &job.variables,
+                &format!("variables for job '{}'", job.job),
+                &mut errors,
+            );
+            if let Some(role) = &job.role {
+                validate_role(role, &format!("role for job '{}'", job.job), &mut errors);
+            }
+        }
+
+        if !errors.is_empty() {
+            return Err(WorkflowError::Validation(errors));
+        }
+
+        let global_role = raw.role.as_deref().unwrap_or("all");
+        let mut jobs = Vec::with_capacity(raw.jobs.len());
+        for job in &raw.jobs {
+            match compile_job(&raw, job, global_role, base_dir) {
+                Ok(compiled) => jobs.push(compiled),
+                Err(mut job_errors) => errors.append(&mut job_errors),
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(WorkflowPlan {
+                version: raw.version,
+                jobs,
+            })
+        } else {
+            Err(WorkflowError::Validation(errors))
+        }
+    }
+
+    fn compile_job(
+        workflow: &RawWorkflow,
+        job: &RawJob,
+        global_role: &str,
+        base_dir: &Path,
+    ) -> Result<WorkflowJob, Vec<String>> {
+        let mut errors = Vec::new();
+        let mut raw_variables = workflow.variables.clone();
+        raw_variables.extend(job.variables.clone());
+
+        let variables = match resolve_variables(&raw_variables, &job.job) {
+            Ok(variables) => variables,
+            Err(mut variable_errors) => {
+                for error in &mut variable_errors {
+                    *error = format!("job '{}': {error}", job.job);
+                }
+                errors.append(&mut variable_errors);
+                HashMap::new()
+            }
+        };
+
+        let workspace = match interpolate(&job.workspace, &variables) {
+            Ok(path) => match existing_path(&path, base_dir) {
+                Ok(path) if path.is_dir() => Some(path),
+                Ok(path) => {
+                    errors.push(format!(
+                        "job '{}': workspace '{}' is not a directory",
+                        job.job,
+                        path.display()
+                    ));
+                    None
+                }
+                Err(error) => {
+                    errors.push(format!("job '{}': workspace {error}", job.job));
+                    None
+                }
+            },
+            Err(error) => {
+                errors.push(format!("job '{}': workspace {error}", job.job));
+                None
+            }
+        };
+
+        // Functions keep their bodies: `call` runs them at execution time so
+        // `return` and `break` behave across call boundaries. Approvals apply
+        // to later steps in the same function or `main` list, so each scope
+        // compiles with its own approval set: a function either approves its
+        // own external paths or its caller approves before the `call`.
+        let scope = workspace.as_deref().unwrap_or(base_dir);
+        let mut functions = BTreeMap::new();
+        for (name, body) in &workflow.functions {
+            let mut bound = Vec::new();
+            match compile_block(body, &variables, scope, &mut bound) {
+                Ok(steps) => {
+                    functions.insert(name.clone(), steps);
+                }
+                Err(error) => errors.push(format!("job '{}': function '{name}' {error}", job.job)),
+            }
+        }
+        let mut steps = Vec::new();
+        if !variables.is_empty() {
+            let mut bound = Vec::new();
+            match compile_block(&workflow.main, &variables, scope, &mut bound) {
+                Ok(main) => steps = main,
+                Err(error) => errors.push(format!("job '{}': {error}", job.job)),
+            }
+        }
+
+        if errors.is_empty() {
+            let scope = workspace
+                .as_deref()
+                .expect("workspace exists when no errors were recorded");
+            let mut approved = HashSet::new();
+            let mut bound = Vec::new();
+            let mut call_stack = Vec::new();
+            if let Err(error) = check_raw_approvals(
+                &workflow.main,
+                &workflow.functions,
+                &variables,
+                scope,
+                &mut approved,
+                &mut bound,
+                &mut call_stack,
+            ) {
+                errors.push(format!("job '{}': {error}", job.job));
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(WorkflowJob {
+                name: job.job.clone(),
+                workspace: workspace.expect("workspace exists when no errors were recorded"),
+                role: job.role.as_deref().unwrap_or(global_role).to_string(),
+                steps,
+                functions,
+            })
+        } else {
+            Err(errors)
+        }
+    }
+
+    fn validate_role(role: &str, context: &str, errors: &mut Vec<String>) {
+        if !KNOWN_ROLES.contains(&role) {
+            errors.push(format!(
+                "{context} '{role}' is unknown; expected one of {}",
+                KNOWN_ROLES.join(", ")
+            ));
+        }
+    }
+
+    fn validate_variable_names(
+        variables: &BTreeMap<String, Scalar>,
+        context: &str,
+        errors: &mut Vec<String>,
+    ) {
+        for name in variables.keys() {
+            if name == "job" {
+                errors.push(format!(
+                    "{context}: 'job' is reserved for the current job name"
+                ));
+            } else if !valid_identifier(name) {
+                errors.push(format!(
+                "{context}: variable '{name}' must start with a letter or underscore and contain only letters, digits, or underscores"
+            ));
+            }
+        }
+    }
+
+    fn valid_identifier(name: &str) -> bool {
+        let mut chars = name.chars();
+        let Some(first) = chars.next() else {
+            return false;
+        };
+        (first == '_' || first.is_ascii_alphabetic())
+            && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+    }
+
+    fn validate_functions(
+        functions: &BTreeMap<String, Vec<RawStep>>,
+        main: &[RawStep],
+        errors: &mut Vec<String>,
+    ) {
+        for (name, steps) in functions {
+            if !valid_identifier(name) {
+                errors.push(format!(
+                "function name '{name}' must start with a letter or underscore and contain only letters, digits, or underscores"
+            ));
+            }
+            if steps.is_empty() {
+                errors.push(format!("function '{name}' must contain at least one step"));
+            }
+            validate_block(
+                steps,
+                &format!("function '{name}'"),
+                false,
+                true,
+                &[],
+                errors,
+            );
+        }
+        validate_block(main, "main", false, false, &[], errors);
+
+        let mut visiting = Vec::new();
+        let mut visited = HashSet::new();
+        for name in functions.keys() {
+            visit_function(name, functions, &mut visiting, &mut visited, errors);
+        }
+        for called in nested_calls(main) {
+            if !functions.contains_key(called) {
+                errors.push(format!("main calls unknown function '{called}'"));
+            }
+        }
+    }
+
+    /// Every `call` target in a step list, including inside `if` branches and
+    /// `for`/`while` bodies. Recursion and unknown calls are rejected before
+    /// execution no matter how deeply a call is nested.
+    fn nested_calls(steps: &[RawStep]) -> Vec<&str> {
+        let mut calls = Vec::new();
+        for step in steps {
+            match step.kind() {
+                Ok(StepKind::Call(name)) => calls.push(name),
+                Ok(StepKind::If(body)) => {
+                    calls.extend(nested_calls(&body.then));
+                    if let Some(other) = &body.r#else {
+                        calls.extend(nested_calls(other));
+                    }
+                }
+                Ok(StepKind::For(body)) => calls.extend(nested_calls(&body.body)),
+                Ok(StepKind::While(body)) => calls.extend(nested_calls(&body.body)),
+                _ => {}
+            }
+        }
+        calls
+    }
+
+    /// Validate one step list. `in_loop` tracks lexical nesting inside
+    /// `for`/`while` bodies so `break` is accepted only there; `in_function`
+    /// tracks function bodies so `return` is rejected in `main`. `bound`
+    /// holds the active `for` variables for shadowing checks. Labels and
+    /// `goto`s pair up inside the list that declares them: a jump never
+    /// crosses a function boundary or enters a nested block implicitly.
+    fn validate_block(
+        steps: &[RawStep],
+        context: &str,
+        in_loop: bool,
+        in_function: bool,
+        bound: &[String],
+        errors: &mut Vec<String>,
+    ) {
+        let mut labels = HashSet::new();
+        for (index, step) in steps.iter().enumerate() {
+            if let Some(label) = &step.label {
+                if label.trim().is_empty() || !valid_identifier(label) {
+                    errors.push(format!(
+                        "{context} step {} has an invalid label; labels must start with a letter or underscore and contain only letters, digits, or underscores",
+                        index + 1
+                    ));
+                } else if !labels.insert(label.as_str()) {
+                    errors.push(format!(
+                        "{context} step {} redefines label '{label}'",
+                        index + 1
+                    ));
+                }
+            }
+        }
+        for (index, step) in steps.iter().enumerate() {
+            let step_no = index + 1;
+            match step.kind() {
+                Ok(StepKind::Command(command)) if command.trim().is_empty() => {
+                    errors.push(format!("{context} step {step_no} has an empty command"));
+                }
+                Ok(StepKind::Call(name)) if name.trim().is_empty() => {
+                    errors.push(format!("{context} step {step_no} has an empty call"));
+                }
+                Ok(StepKind::Approved(values))
+                    if values.values().next().is_none()
+                        || values.values().any(|path| path.trim().is_empty()) =>
+                {
+                    errors.push(format!(
+                        "{context} step {step_no} has an empty approved path"
+                    ));
+                }
+                Ok(StepKind::Loop(spec)) => validate_loop_shape(spec, context, index, errors),
+                Ok(StepKind::If(body)) => {
+                    if body.condition.trim().is_empty() {
+                        errors.push(format!(
+                            "{context} step {step_no} has an empty if condition"
+                        ));
+                    }
+                    if body.then.is_empty() {
+                        errors.push(format!("{context} step {step_no} has an empty then branch"));
+                    } else {
+                        validate_block(
+                            &body.then,
+                            &format!("{context} step {step_no} then"),
+                            in_loop,
+                            in_function,
+                            bound,
+                            errors,
+                        );
+                    }
+                    if let Some(other) = &body.r#else {
+                        if other.is_empty() {
+                            errors
+                                .push(format!("{context} step {step_no} has an empty else branch"));
+                        } else {
+                            validate_block(
+                                other,
+                                &format!("{context} step {step_no} else"),
+                                in_loop,
+                                in_function,
+                                bound,
+                                errors,
+                            );
+                        }
+                    }
+                }
+                Ok(StepKind::For(body)) => {
+                    if body.var == "job" {
+                        errors.push(format!(
+                            "{context} step {step_no}: 'job' is reserved for the current job name"
+                        ));
+                    } else if !valid_identifier(&body.var) {
+                        errors.push(format!(
+                            "{context} step {step_no} has an invalid for variable '{}'; variables must start with a letter or underscore and contain only letters, digits, or underscores",
+                            body.var
+                        ));
+                    } else if bound.iter().any(|name| name == &body.var) {
+                        errors.push(format!(
+                            "{context} step {step_no} shadows the outer for variable '{}'",
+                            body.var
+                        ));
+                    }
+                    match (&body.items, &body.range) {
+                        (Some(_), Some(_)) => errors.push(format!(
+                            "{context} step {step_no} for accepts either items or range, not both"
+                        )),
+                        (None, None) => errors
+                            .push(format!("{context} step {step_no} for needs items or range")),
+                        (Some(items), None) => {
+                            if items.is_empty() {
+                                errors.push(format!(
+                                    "{context} step {step_no} for needs at least one item"
+                                ));
+                            } else if items.len() > MAX_FOR_ITEMS {
+                                errors.push(format!(
+                                    "{context} step {step_no} for has {} items; at most {MAX_FOR_ITEMS} are allowed",
+                                    items.len()
+                                ));
+                            } else if items.iter().any(|item| item.trim().is_empty()) {
+                                errors.push(format!(
+                                    "{context} step {step_no} for has an empty item"
+                                ));
+                            }
+                        }
+                        (None, Some(range)) => {
+                            if expand_range(range).is_err() {
+                                errors.push(format!(
+                                    "{context} step {step_no} has an invalid for range '{range}'; use Start..End with at most {MAX_FOR_RANGE_SPAN} values"
+                                ));
+                            }
+                        }
+                    }
+                    if body.body.is_empty() {
+                        errors.push(format!("{context} step {step_no} has an empty for body"));
+                    } else {
+                        let mut inner = bound.to_vec();
+                        inner.push(body.var.clone());
+                        validate_block(
+                            &body.body,
+                            &format!("{context} step {step_no} for"),
+                            true,
+                            in_function,
+                            &inner,
+                            errors,
+                        );
+                    }
+                }
+                Ok(StepKind::While(body)) => {
+                    if body.condition.trim().is_empty() {
+                        errors.push(format!(
+                            "{context} step {step_no} has an empty while condition"
+                        ));
+                    }
+                    if body.max_turns == 0 || body.max_turns > MAX_WHILE_TURNS {
+                        errors.push(format!(
+                            "{context} step {step_no} while max_turns must be between 1 and {MAX_WHILE_TURNS}"
+                        ));
+                    }
+                    if body.body.is_empty() {
+                        errors.push(format!("{context} step {step_no} has an empty while body"));
+                    } else {
+                        validate_block(
+                            &body.body,
+                            &format!("{context} step {step_no} while"),
+                            true,
+                            in_function,
+                            bound,
+                            errors,
+                        );
+                    }
+                }
+                Ok(StepKind::Break) => {
+                    if !in_loop {
+                        errors.push(format!(
+                            "{context} step {step_no} has break outside a for or while loop"
+                        ));
+                    }
+                }
+                Ok(StepKind::Return) => {
+                    if !in_function {
+                        errors.push(format!(
+                            "{context} step {step_no} has return outside a function"
+                        ));
+                    }
+                }
+                Ok(StepKind::Label(_)) => {}
+                Ok(StepKind::Goto(target)) => {
+                    if target.trim().is_empty() || !valid_identifier(target) {
+                        errors.push(format!(
+                            "{context} step {step_no} has an invalid goto label"
+                        ));
+                    } else if !labels.contains(target) {
+                        errors.push(format!(
+                            "{context} step {step_no} jumps to unknown label '{target}' in the same step list"
+                        ));
+                    }
+                }
+                Ok(_) => {}
+                Err(error) => errors.push(format!("{context} step {step_no} {error}")),
+            }
+        }
+    }
+
+    /// Expand a finite `Start..End` range into its values. Bounds are checked
+    /// by the validator; this is the shared expansion used at compile time.
+    fn expand_range(range: &str) -> Result<Vec<String>, ()> {
+        let (start, end) = range.split_once("..").ok_or(())?;
+        let start: u64 = start.trim().parse().map_err(|_| ())?;
+        let end: u64 = end.trim().parse().map_err(|_| ())?;
+        if start > end || end - start + 1 > MAX_FOR_RANGE_SPAN {
+            return Err(());
+        }
+        Ok((start..=end).map(|value| value.to_string()).collect())
+    }
+
+    fn validate_loop_shape(spec: &RawLoop, context: &str, index: usize, errors: &mut Vec<String>) {
+        let step = index + 1;
+        if spec.objective.trim().is_empty() {
+            errors.push(format!("{context} step {step} has an empty loop objective"));
+        }
+        match &spec.stop {
+            RawLoopStop::Turns { count: 0 } => errors.push(format!(
+                "{context} step {step} loop turn count must be greater than zero"
+            )),
+            RawLoopStop::Time { duration } if duration.trim().is_empty() => {
+                errors.push(format!("{context} step {step} has an empty loop duration"))
+            }
+            RawLoopStop::Goal { condition } if condition.trim().is_empty() => errors.push(format!(
+                "{context} step {step} has an empty loop goal condition"
+            )),
+            _ => {}
+        }
+        if spec
+            .review
+            .checks
+            .iter()
+            .any(|check| check.trim().is_empty())
+        {
+            errors.push(format!(
+                "{context} step {step} has an empty loop validation command"
+            ));
+        }
+        if spec
+            .review
+            .rubric
+            .iter()
+            .any(|criterion| criterion.trim().is_empty())
+        {
+            errors.push(format!(
+                "{context} step {step} has an empty loop review criterion"
+            ));
+        }
+    }
+
+    fn visit_function<'a>(
+        name: &'a str,
+        functions: &'a BTreeMap<String, Vec<RawStep>>,
+        visiting: &mut Vec<&'a str>,
+        visited: &mut HashSet<&'a str>,
+        errors: &mut Vec<String>,
+    ) {
+        if visited.contains(name) {
+            return;
+        }
+        if let Some(position) = visiting.iter().position(|candidate| *candidate == name) {
+            let mut cycle = visiting[position..].to_vec();
+            cycle.push(name);
+            errors.push(format!("recursive function call: {}", cycle.join(" -> ")));
+            return;
+        }
+        let Some(steps) = functions.get(name) else {
+            return;
+        };
+        visiting.push(name);
+        for called in nested_calls(steps) {
+            if functions.contains_key(called) {
+                visit_function(called, functions, visiting, visited, errors);
+            } else {
+                errors.push(format!(
+                    "function '{name}' calls unknown function '{called}'"
+                ));
+            }
+        }
+        visiting.pop();
+        visited.insert(name);
+    }
+
+    impl RawStep {
+        fn kind(&self) -> Result<StepKind<'_>, &'static str> {
+            const OPTIONS: &str = "must contain exactly one of 'command', 'call', 'approved', 'loop', 'if', 'for', 'while', 'break', 'return', 'label', or 'goto'";
+            let count = usize::from(self.command.is_some())
+                + usize::from(self.call.is_some())
+                + usize::from(self.approved.is_some())
+                + usize::from(self.r#loop.is_some())
+                + usize::from(self.r#if.is_some())
+                + usize::from(self.r#for.is_some())
+                + usize::from(self.r#while.is_some())
+                + usize::from(self.r#break.is_some())
+                + usize::from(self.r#return.is_some())
+                + usize::from(self.label.is_some())
+                + usize::from(self.goto.is_some());
+            if count != 1 {
+                return Err(OPTIONS);
+            }
+            if let Some(command) = &self.command {
+                Ok(StepKind::Command(command))
+            } else if let Some(call) = &self.call {
+                Ok(StepKind::Call(call))
+            } else if let Some(approved) = &self.approved {
+                Ok(StepKind::Approved(approved))
+            } else if let Some(r#loop) = &self.r#loop {
+                Ok(StepKind::Loop(r#loop))
+            } else if let Some(r#if) = &self.r#if {
+                Ok(StepKind::If(r#if))
+            } else if let Some(r#for) = &self.r#for {
+                Ok(StepKind::For(r#for))
+            } else if let Some(r#while) = &self.r#while {
+                Ok(StepKind::While(r#while))
+            } else if let Some(r#break) = &self.r#break {
+                if *r#break {
+                    Ok(StepKind::Break)
+                } else {
+                    Err("break takes no value; write '- break: true'")
+                }
+            } else if let Some(r#return) = &self.r#return {
+                if *r#return {
+                    Ok(StepKind::Return)
+                } else {
+                    Err("return takes no value; write '- return: true'")
+                }
+            } else if let Some(label) = &self.label {
+                Ok(StepKind::Label(label))
+            } else {
+                Ok(StepKind::Goto(
+                    self.goto.as_ref().expect("action count checked"),
+                ))
+            }
+        }
+    }
+
+    fn resolve_variables(
+        raw: &BTreeMap<String, Scalar>,
+        job: &str,
+    ) -> Result<HashMap<String, String>, Vec<String>> {
+        let mut resolved = HashMap::new();
+        resolved.insert("job".to_string(), job.to_string());
+        let mut errors = Vec::new();
+        for name in raw.keys() {
+            let mut stack = Vec::new();
+            if let Err(error) = resolve_variable(name, raw, &mut resolved, &mut stack) {
+                errors.push(error);
+            }
+        }
+        if errors.is_empty() {
+            Ok(resolved)
+        } else {
+            errors.sort();
+            errors.dedup();
+            Err(errors)
+        }
+    }
+
+    fn resolve_variable(
+        name: &str,
+        raw: &BTreeMap<String, Scalar>,
+        resolved: &mut HashMap<String, String>,
+        stack: &mut Vec<String>,
+    ) -> Result<String, String> {
+        if let Some(value) = resolved.get(name) {
+            return Ok(value.clone());
+        }
+        if let Some(position) = stack.iter().position(|candidate| candidate == name) {
+            let mut cycle = stack[position..].to_vec();
+            cycle.push(name.to_string());
+            return Err(format!(
+                "recursive variable reference: {}",
+                cycle.join(" -> ")
+            ));
+        }
+        let value = raw
+            .get(name)
+            .ok_or_else(|| format!("undefined variable '{name}'"))?;
+        stack.push(name.to_string());
+        let text = interpolate_with(&value.text(), |referenced| {
+            resolve_variable(referenced, raw, resolved, stack)
+        })?;
+        stack.pop();
+        resolved.insert(name.to_string(), text.clone());
+        Ok(text)
+    }
+
+    fn interpolate(input: &str, variables: &HashMap<String, String>) -> Result<String, String> {
+        interpolate_with(input, |name| {
+            variables
+                .get(name)
+                .cloned()
+                .ok_or_else(|| format!("references undefined variable '{name}'"))
+        })
+    }
+
+    fn interpolate_with(
+        input: &str,
+        mut resolve: impl FnMut(&str) -> Result<String, String>,
+    ) -> Result<String, String> {
+        let mut output = String::with_capacity(input.len());
+        let mut rest = input;
+        while let Some(start) = rest.find("${") {
+            output.push_str(&rest[..start]);
+            let expression = &rest[start + 2..];
+            let Some(end) = expression.find('}') else {
+                return Err(format!(
+                    "contains an unterminated variable reference: '{input}'"
+                ));
+            };
+            let name = &expression[..end];
+            if !valid_identifier(name) {
+                return Err(format!("contains invalid variable reference '${{{name}}}'"));
+            }
+            output.push_str(&resolve(name)?);
+            rest = &expression[end + 1..];
+        }
+        output.push_str(rest);
+        Ok(output)
+    }
+
+    /// Compile one step list into its executable tree. `bound` holds the
+    /// active `for` variables, whose `${var}` references are left for
+    /// execution time to substitute. External-path approvals are checked
+    /// separately by [`check_approvals`], which walks the compiled tree in
+    /// execution order.
+    fn compile_block(
+        raw_steps: &[RawStep],
+        variables: &HashMap<String, String>,
+        workspace: &Path,
+        bound: &mut Vec<String>,
+    ) -> Result<Vec<WorkflowStep>, String> {
+        let mut output = Vec::with_capacity(raw_steps.len());
+        for step in raw_steps {
+            match step.kind().map_err(str::to_string)? {
+                StepKind::Command(command) => {
+                    let command = interpolate_scoped(command, variables, bound)?;
+                    output.push(WorkflowStep::Command(command));
+                }
+                StepKind::Approved(paths) => {
+                    for path in paths.values() {
+                        for name in variable_references(path)? {
+                            if bound.iter().any(|active| active == name) {
+                                return Err(format!(
+                                    "approved paths cannot use the for-loop variable '${{{name}}}'; approve a concrete path before the loop"
+                                ));
+                            }
+                        }
+                        let path = interpolate_scoped(path, variables, bound)?;
+                        let path = existing_path(&path, workspace)
+                            .map_err(|error| format!("approved path {error}"))?;
+                        output.push(WorkflowStep::Approved(path));
+                    }
+                }
+                StepKind::Loop(spec) => output.push(WorkflowStep::Loop(compile_loop(
+                    spec, variables, workspace, bound,
+                )?)),
+                StepKind::Call(name) => output.push(WorkflowStep::Call(name.to_string())),
+                StepKind::If(body) => {
+                    let condition = interpolate_scoped(&body.condition, variables, bound)?;
+                    if condition.trim().is_empty() {
+                        return Err("has an empty if condition".to_string());
+                    }
+                    let then_branch = compile_block(&body.then, variables, workspace, bound)?;
+                    let else_branch = match &body.r#else {
+                        Some(other) => compile_block(other, variables, workspace, bound)?,
+                        None => Vec::new(),
+                    };
+                    output.push(WorkflowStep::If {
+                        condition,
+                        then_branch,
+                        else_branch,
+                    });
+                }
+                StepKind::For(body) => {
+                    let items = match (&body.items, &body.range) {
+                        (Some(items), None) => items
+                            .iter()
+                            .map(|item| interpolate_scoped(item, variables, bound))
+                            .collect::<Result<Vec<_>, _>>()?,
+                        (None, Some(range)) => {
+                            let range = interpolate_scoped(range, variables, bound)?;
+                            expand_range(&range)
+                                .map_err(|_| format!("has an invalid for range '{range}'"))?
+                        }
+                        _ => return Err("for needs items or range".to_string()),
+                    };
+                    if items.iter().any(|item| item.trim().is_empty()) {
+                        return Err("for has an empty item".to_string());
+                    }
+                    bound.push(body.var.clone());
+                    let compiled = compile_block(&body.body, variables, workspace, bound)?;
+                    bound.pop();
+                    output.push(WorkflowStep::For {
+                        var: body.var.clone(),
+                        items,
+                        body: compiled,
+                    });
+                }
+                StepKind::While(body) => {
+                    let condition = interpolate_scoped(&body.condition, variables, bound)?;
+                    if condition.trim().is_empty() {
+                        return Err("has an empty while condition".to_string());
+                    }
+                    let compiled = compile_block(&body.body, variables, workspace, bound)?;
+                    output.push(WorkflowStep::While {
+                        condition,
+                        max_turns: body.max_turns,
+                        body: compiled,
+                    });
+                }
+                StepKind::Break => output.push(WorkflowStep::Break),
+                StepKind::Return => output.push(WorkflowStep::Return),
+                StepKind::Label(name) => output.push(WorkflowStep::Label(name.to_string())),
+                StepKind::Goto(target) => output.push(WorkflowStep::Goto(target.to_string())),
+            }
+        }
+        Ok(output)
+    }
+
+    /// Check external variable paths in execution order on the raw steps,
+    /// descending into function calls and both `if` branches. An `approved`
+    /// step authorizes later uses wherever the run can reach them — including
+    /// inside a called function or after it returns — exactly as if the calls
+    /// were inlined. Branch and loop bodies share the scope's approval set:
+    /// validation is conservative and accepts an approval that precedes the
+    /// branch or loop. Loop checks obey the same ordering: an approval must
+    /// precede the `loop` step whose checks use the path. Raw text is checked
+    /// before interpolation so `${var}` references are still visible.
+    fn check_raw_approvals(
+        raw_steps: &[RawStep],
+        functions: &BTreeMap<String, Vec<RawStep>>,
+        variables: &HashMap<String, String>,
+        workspace: &Path,
+        approved: &mut HashSet<PathBuf>,
+        bound: &mut Vec<String>,
+        call_stack: &mut Vec<String>,
+    ) -> Result<(), String> {
+        for step in raw_steps {
+            match step.kind().map_err(str::to_string)? {
+                StepKind::Command(command) => {
+                    validate_external_variable_paths(
+                        command, variables, workspace, approved, bound,
+                    )?;
+                }
+                StepKind::Approved(paths) => {
+                    for path in paths.values() {
+                        let path = interpolate_scoped(path, variables, bound)?;
+                        let path = existing_path(&path, workspace)
+                            .map_err(|error| format!("approved path {error}"))?;
+                        approved.insert(path);
+                    }
+                }
+                StepKind::Loop(spec) => {
+                    for check in &spec.review.checks {
+                        validate_external_variable_paths(
+                            check, variables, workspace, approved, bound,
+                        )?;
+                    }
+                }
+                StepKind::Call(name) => {
+                    if call_stack.iter().any(|called| called == name) {
+                        let mut cycle = call_stack.clone();
+                        cycle.push(name.to_string());
+                        return Err(format!("recursive function call: {}", cycle.join(" -> ")));
+                    }
+                    let body = functions
+                        .get(name)
+                        .ok_or_else(|| format!("calls unknown function '{name}'"))?;
+                    call_stack.push(name.to_string());
+                    check_raw_approvals(
+                        body, functions, variables, workspace, approved, bound, call_stack,
+                    )?;
+                    call_stack.pop();
+                }
+                StepKind::If(body) => {
+                    validate_external_variable_paths(
+                        &body.condition,
+                        variables,
+                        workspace,
+                        approved,
+                        bound,
+                    )?;
+                    check_raw_approvals(
+                        &body.then, functions, variables, workspace, approved, bound, call_stack,
+                    )?;
+                    if let Some(other) = &body.r#else {
+                        check_raw_approvals(
+                            other, functions, variables, workspace, approved, bound, call_stack,
+                        )?;
+                    }
+                }
+                StepKind::For(body) => {
+                    bound.push(body.var.clone());
+                    check_raw_approvals(
+                        &body.body, functions, variables, workspace, approved, bound, call_stack,
+                    )?;
+                    bound.pop();
+                }
+                StepKind::While(body) => {
+                    validate_external_variable_paths(
+                        &body.condition,
+                        variables,
+                        workspace,
+                        approved,
+                        bound,
+                    )?;
+                    check_raw_approvals(
+                        &body.body, functions, variables, workspace, approved, bound, call_stack,
+                    )?;
+                }
+                StepKind::Break | StepKind::Return | StepKind::Label(_) | StepKind::Goto(_) => {}
+            }
+        }
+        Ok(())
+    }
+
+    /// Like [`interpolate`], but references to active `for` variables are
+    /// left as `${var}` placeholders for execution time to substitute.
+    fn interpolate_scoped(
+        input: &str,
+        variables: &HashMap<String, String>,
+        bound: &[String],
+    ) -> Result<String, String> {
+        interpolate_with(input, |name| {
+            if bound.iter().any(|active| active == name) {
+                Ok(format!("${{{name}}}"))
+            } else {
+                variables
+                    .get(name)
+                    .cloned()
+                    .ok_or_else(|| format!("references undefined variable '{name}'"))
+            }
+        })
+    }
+
+    /// Paths supplied through variables are the part of a shell command the YAML
+    /// layer can identify without attempting to parse a shell language. An
+    /// absolute variable that resolves outside the workspace therefore needs a
+    /// preceding `approved` step. Literal shell text keeps the existing `/shell`
+    /// semantics; the workflow layer does not pretend to be a portable shell
+    /// sandbox.
+    fn validate_external_variable_paths(
+        command: &str,
+        variables: &HashMap<String, String>,
+        workspace: &Path,
+        approved: &HashSet<PathBuf>,
+        bound: &[String],
+    ) -> Result<(), String> {
+        for name in variable_references(command)? {
+            if bound.iter().any(|active| active == name) {
+                continue;
+            }
+            let Some(value) = variables.get(name) else {
+                continue;
+            };
+            let expanded = expand_home(value)?;
+            let path = PathBuf::from(expanded);
+            let path = if path.is_absolute() {
+                path
+            } else {
+                workspace.join(path)
+            };
+            if !path.exists() {
+                continue;
+            }
+            let canonical = path
+                .canonicalize()
+                .map_err(|error| format!("variable '{name}' path '{}': {error}", path.display()))?;
+            let explicitly_approved = approved.iter().any(|path| canonical.starts_with(path));
+            if !canonical.starts_with(workspace) && !explicitly_approved {
+                return Err(format!(
+                    "command uses variable '{name}' outside the workspace; add an approved step for '{}' before the command",
+                    canonical.display()
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn variable_references(input: &str) -> Result<Vec<&str>, String> {
+        let mut references = Vec::new();
+        let mut rest = input;
+        while let Some(start) = rest.find("${") {
+            let expression = &rest[start + 2..];
+            let Some(end) = expression.find('}') else {
+                return Err(format!(
+                    "contains an unterminated variable reference: '{input}'"
+                ));
+            };
+            let name = &expression[..end];
+            if !valid_identifier(name) {
+                return Err(format!("contains invalid variable reference '${{{name}}}'"));
+            }
+            references.push(name);
+            rest = &expression[end + 1..];
+        }
+        Ok(references)
+    }
+
+    fn compile_loop(
+        raw: &RawLoop,
+        variables: &HashMap<String, String>,
+        _workspace: &Path,
+        bound: &[String],
+    ) -> Result<WorkflowLoop, String> {
+        let objective = interpolate_scoped(&raw.objective, variables, bound)?;
+        if objective.trim().is_empty() {
+            return Err("has an empty loop objective".to_string());
+        }
+        let stop = match &raw.stop {
+            RawLoopStop::Turns { count } if *count > 0 => WorkflowLoopStop::Turns(*count),
+            RawLoopStop::Turns { .. } => {
+                return Err("loop turn count must be greater than zero".to_string());
+            }
+            RawLoopStop::Time { duration } => {
+                let duration = interpolate_scoped(duration, variables, bound)?;
+                WorkflowLoopStop::Time(parse_duration(&duration)?)
+            }
+            RawLoopStop::Goal { condition } => {
+                let condition = interpolate_scoped(condition, variables, bound)?;
+                if condition.trim().is_empty() {
+                    return Err("has an empty loop goal condition".to_string());
+                }
+                WorkflowLoopStop::Goal(condition)
+            }
+        };
+
+        let mut checks = Vec::with_capacity(raw.review.checks.len());
+        for check in &raw.review.checks {
+            checks.push(interpolate_scoped(check, variables, bound)?);
+        }
+        let rubric = raw
+            .review
+            .rubric
+            .iter()
+            .map(|criterion| interpolate_scoped(criterion, variables, bound))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(WorkflowLoop {
+            objective,
+            stop,
+            checks,
+            rubric,
+        })
+    }
+
+    fn parse_duration(input: &str) -> Result<Duration, String> {
+        let input = input.trim();
+        let Some(index) = input.find(|character: char| !character.is_ascii_digit()) else {
+            return Err(format!(
+                "invalid loop duration '{input}'; use a positive value such as 30m or 2h"
+            ));
+        };
+        let (number, unit) = input.split_at(index);
+        if number.is_empty()
+            || unit.is_empty()
+            || unit.chars().any(|character| character.is_whitespace())
+        {
+            return Err(format!(
+                "invalid loop duration '{input}'; use a positive value such as 30m or 2h"
+            ));
+        }
+        let value: u64 = number
+            .parse()
+            .map_err(|_| format!("invalid loop duration '{input}'"))?;
+        if value == 0 {
+            return Err("loop duration must be greater than zero".to_string());
+        }
+        let seconds = match unit {
+            "s" => value,
+            "m" => value
+                .checked_mul(60)
+                .ok_or_else(|| "loop duration is too large".to_string())?,
+            "h" => value
+                .checked_mul(60 * 60)
+                .ok_or_else(|| "loop duration is too large".to_string())?,
+            "d" => value
+                .checked_mul(24 * 60 * 60)
+                .ok_or_else(|| "loop duration is too large".to_string())?,
+            _ => {
+                return Err(format!(
+                    "invalid loop duration unit in '{input}'; use s, m, h, or d"
+                ));
+            }
+        };
+        Ok(Duration::from_secs(seconds))
+    }
+
+    fn existing_path(raw: &str, relative_to: &Path) -> Result<PathBuf, String> {
+        let expanded = expand_home(raw)?;
+        let path = PathBuf::from(expanded);
+        let path = if path.is_absolute() {
+            path
+        } else {
+            relative_to.join(path)
+        };
+        path.canonicalize()
+            .map_err(|error| format!("'{}' cannot be resolved: {error}", path.display()))
+    }
+
+    fn expand_home(path: &str) -> Result<String, String> {
+        if path == "~" || path.starts_with("~/") {
+            let home = home::home_dir()
+                .ok_or_else(|| "uses '~' but no home directory is known".to_string())?;
+            if path == "~" {
+                Ok(home.display().to_string())
+            } else {
+                Ok(home.join(&path[2..]).display().to_string())
+            }
+        } else {
+            Ok(path.to_string())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::fs;
+        use tempfile::tempdir;
+
+        #[test]
+        fn compiles_export_workflow_for_every_job() {
+            let root = tempdir().expect("root");
+            let upstream = root.path().join("Upstream");
+            let pgagroal = root.path().join("pgagroal");
+            let orangu = root.path().join("orangu");
+            fs::create_dir_all(&upstream).expect("upstream");
+            fs::create_dir_all(&pgagroal).expect("pgagroal");
+            fs::create_dir_all(&orangu).expect("orangu");
+
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  variables:
+    upstream: {upstream:?}
+    root: {root:?}
+  jobs:
+    - job: pgagroal
+      workspace: ${{root}}/pgagroal
+    - job: orangu
+      workspace: ${{root}}/orangu
+      role: code
+  functions:
+    export_pr:
+      - command: /export pr
+    move_pdf:
+      - command: /shell mv ${{job}}-pr.pdf ${{upstream}}/
+    check_orangu:
+      - approved: ${{upstream}}
+      - call: export_pr
+      - call: move_pdf
+  main:
+    - call: check_orangu
+"#,
+                upstream = upstream.display().to_string(),
+                root = root.path().display().to_string(),
+            );
+
+            let plan = compile(&yaml, root.path()).expect("valid workflow");
+            assert_eq!(plan.version, 1);
+            assert_eq!(plan.jobs.len(), 2);
+            assert_eq!(plan.jobs[0].name, "pgagroal");
+            assert_eq!(plan.jobs[0].role, "all");
+            assert_eq!(plan.jobs[1].role, "code");
+            // Calls stay calls: functions run at execution time so `return`
+            // and `break` behave across call boundaries.
+            assert_eq!(
+                plan.jobs[0].steps,
+                vec![WorkflowStep::Call("check_orangu".to_string())]
+            );
+            let functions = &plan.jobs[0].functions;
+            assert_eq!(
+                functions["export_pr"],
+                vec![WorkflowStep::Command("/export pr".to_string())]
+            );
+            assert_eq!(
+                functions["move_pdf"],
+                vec![WorkflowStep::Command(format!(
+                    "/shell mv pgagroal-pr.pdf {}/",
+                    upstream.display()
+                ))]
+            );
+            assert_eq!(
+                functions["check_orangu"],
+                vec![
+                    WorkflowStep::Approved(upstream.canonicalize().expect("canonical upstream")),
+                    WorkflowStep::Call("export_pr".to_string()),
+                    WorkflowStep::Call("move_pdf".to_string()),
+                ]
+            );
+        }
+
+        #[test]
+        fn job_variables_override_global_variables() {
+            let root = tempdir().expect("root");
+            let workspace = root.path().join("repo");
+            fs::create_dir(&workspace).expect("workspace");
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  variables:
+    action: status
+  jobs:
+    - job: repo
+      workspace: {workspace:?}
+      variables:
+        action: diff
+  functions: {{}}
+  main:
+    - command: /${{action}}
+"#,
+                workspace = workspace.display().to_string(),
+            );
+            let plan = compile(&yaml, root.path()).expect("valid workflow");
+            assert_eq!(
+                plan.jobs[0].steps,
+                vec![WorkflowStep::Command("/diff".to_string())]
+            );
+        }
+
+        #[test]
+        fn rejects_unknown_fields_and_malformed_steps() {
+            let yaml = r#"orangu:
+  version: 1
+  surprise: true
+  jobs: []
+  main: []
+"#;
+            let error = compile(yaml, Path::new(".")).expect_err("unknown field");
+            assert!(error.to_string().contains("unknown field `surprise`"));
+
+            let root = tempdir().expect("root");
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  jobs:
+    - job: repo
+      workspace: {workspace:?}
+  main:
+    - command: /status
+      call: other
+"#,
+                workspace = root.path().display().to_string(),
+            );
+            let error = compile(&yaml, root.path()).expect_err("two actions");
+            assert!(error.to_string().contains("exactly one of"));
+        }
+
+        #[test]
+        fn validates_all_jobs_before_returning() {
+            let root = tempdir().expect("root");
+            let yaml = r#"orangu:
+  version: 1
+  jobs:
+    - job: first
+      workspace: missing-one
+    - job: second
+      workspace: missing-two
+  main:
+    - command: /export ${missing}
+"#;
+            let error = compile(yaml, root.path()).expect_err("invalid jobs");
+            let message = error.to_string();
+            assert!(message.contains("job 'first'"));
+            assert!(message.contains("job 'second'"));
+            assert!(message.contains("undefined variable 'missing'"));
+        }
+
+        #[test]
+        fn rejects_unknown_and_recursive_function_calls() {
+            let root = tempdir().expect("root");
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  jobs:
+    - job: repo
+      workspace: {workspace:?}
+  functions:
+    first:
+      - call: second
+    second:
+      - call: first
+    unused:
+      - call: missing
+  main:
+    - call: first
+"#,
+                workspace = root.path().display().to_string(),
+            );
+            let error = compile(&yaml, root.path()).expect_err("invalid calls");
+            let message = error.to_string();
+            assert!(message.contains("recursive function call"));
+            assert!(message.contains("calls unknown function 'missing'"));
+        }
+
+        #[test]
+        fn rejects_recursive_and_undefined_variables() {
+            let root = tempdir().expect("root");
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  variables:
+    first: ${{second}}
+    second: ${{first}}
+  jobs:
+    - job: repo
+      workspace: {workspace:?}
+  main:
+    - command: /export ${{missing}}
+"#,
+                workspace = root.path().display().to_string(),
+            );
+            let error = compile(&yaml, root.path()).expect_err("invalid variables");
+            assert!(error.to_string().contains("recursive variable reference"));
+        }
+
+        #[test]
+        fn external_variable_path_requires_prior_approval() {
+            let root = tempdir().expect("root");
+            let workspace = root.path().join("repo");
+            let external = root.path().join("output");
+            fs::create_dir(&workspace).expect("workspace");
+            fs::create_dir(&external).expect("external output");
+
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  variables:
+    output: {external:?}
+  jobs:
+    - job: repo
+      workspace: {workspace:?}
+  main:
+    - command: /shell mv report.pdf ${{output}}/
+"#,
+                external = external.display().to_string(),
+                workspace = workspace.display().to_string(),
+            );
+            let error = compile(&yaml, root.path()).expect_err("external path is not approved");
+            let message = error.to_string();
+            assert!(message.contains("variable 'output' outside the workspace"));
+            assert!(message.contains("add an approved step"));
+        }
+
+        #[test]
+        fn external_approval_must_precede_the_command() {
+            let root = tempdir().expect("root");
+            let workspace = root.path().join("repo");
+            let external = root.path().join("output");
+            fs::create_dir(&workspace).expect("workspace");
+            fs::create_dir(&external).expect("external output");
+
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  variables:
+    output: {external:?}
+  jobs:
+    - job: repo
+      workspace: {workspace:?}
+  main:
+    - command: /shell mv report.pdf ${{output}}/
+    - approved: ${{output}}
+"#,
+                external = external.display().to_string(),
+                workspace = workspace.display().to_string(),
+            );
+            let error = compile(&yaml, root.path()).expect_err("approval comes too late");
+            assert!(error.to_string().contains("before the command"));
+        }
+
+        #[test]
+        fn relative_variable_cannot_escape_the_workspace() {
+            let root = tempdir().expect("root");
+            let workspace = root.path().join("repo");
+            let external = root.path().join("output");
+            fs::create_dir(&workspace).expect("workspace");
+            fs::create_dir(&external).expect("external output");
+
+            let yaml = r#"orangu:
+  version: 1
+  variables:
+    output: ../output
+  jobs:
+    - job: repo
+      workspace: repo
+  main:
+    - command: /shell mv report.pdf ${output}/
+"#;
+            let error = compile(yaml, root.path()).expect_err("relative escape is not approved");
+            assert!(error.to_string().contains("outside the workspace"));
+        }
+
+        #[test]
+        fn compiles_all_code_review_loop_stop_policies() {
+            let root = tempdir().expect("root");
+            let workspace = root.path().join("repo");
+            fs::create_dir(&workspace).expect("workspace");
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  variables:
+    objective: Fix the parser
+    check: cargo test
+  jobs:
+    - job: repo
+      workspace: {workspace:?}
+  main:
+    - loop:
+        objective: "${{objective}}"
+        stop:
+          type: turns
+          count: 3
+        review:
+          checks: ["${{check}}"]
+          rubric: [correctness, regressions]
+    - loop:
+        objective: Work within the time budget
+        stop:
+          type: time
+          duration: 30m
+    - loop:
+        objective: Finish the migration
+        stop:
+          type: goal
+          condition: All tests pass
+"#,
+                workspace = workspace.display().to_string(),
+            );
+
+            let plan = compile(&yaml, root.path()).expect("valid loops");
+            assert_eq!(
+                plan.jobs[0].steps[0],
+                WorkflowStep::Loop(WorkflowLoop {
+                    objective: "Fix the parser".to_string(),
+                    stop: WorkflowLoopStop::Turns(3),
+                    checks: vec!["cargo test".to_string()],
+                    rubric: vec!["correctness".to_string(), "regressions".to_string()],
+                })
+            );
+            assert!(matches!(
+                &plan.jobs[0].steps[1],
+                WorkflowStep::Loop(WorkflowLoop {
+                    stop: WorkflowLoopStop::Time(duration),
+                    ..
+                }) if *duration == Duration::from_secs(30 * 60)
+            ));
+            assert!(matches!(
+                &plan.jobs[0].steps[2],
+                WorkflowStep::Loop(WorkflowLoop {
+                    stop: WorkflowLoopStop::Goal(condition),
+                    ..
+                }) if condition == "All tests pass"
+            ));
+        }
+
+        #[test]
+        fn rejects_invalid_code_review_loops_before_execution() {
+            let root = tempdir().expect("root");
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  jobs:
+    - job: repo
+      workspace: {workspace:?}
+  functions:
+    invalid:
+      - loop:
+          objective: ""
+          stop:
+            type: turns
+            count: 0
+          review:
+            checks: [""]
+            rubric: [""]
+  main:
+    - call: invalid
+"#,
+                workspace = root.path().display().to_string(),
+            );
+            let message = compile(&yaml, root.path())
+                .expect_err("invalid loop")
+                .to_string();
+            assert!(message.contains("empty loop objective"));
+            assert!(message.contains("turn count must be greater than zero"));
+            assert!(message.contains("empty loop validation command"));
+            assert!(message.contains("empty loop review criterion"));
+        }
+
+        #[test]
+        fn compiles_control_flow_steps() {
+            let root = tempdir().expect("root");
+            let workspace = root.path().join("repo");
+            fs::create_dir(&workspace).expect("workspace");
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  jobs:
+    - job: repo
+      workspace: {workspace:?}
+  functions:
+    build_one:
+      - command: /build one
+      - return: true
+      - command: /build unreachable
+  main:
+    - if:
+        condition: /status
+        then:
+          - call: build_one
+        else:
+          - command: /diff
+    - for:
+        var: target
+        range: 1..2
+        do:
+          - command: /build ${{target}}
+          - break: true
+    - while:
+        condition: /status
+        max_turns: 3
+        do:
+          - command: /test
+    - label: done
+    - goto: done
+"#,
+                workspace = workspace.display().to_string(),
+            );
+            let plan = compile(&yaml, root.path()).expect("valid control flow");
+            assert!(matches!(
+                &plan.jobs[0].steps[0],
+                WorkflowStep::If { then_branch, else_branch, .. }
+                if then_branch.len() == 1 && else_branch.len() == 1
+            ));
+            assert!(matches!(
+                &plan.jobs[0].steps[1],
+                WorkflowStep::For { var, items, .. }
+                if var == "target" && items == &vec!["1".to_string(), "2".to_string()]
+            ));
+            assert!(matches!(
+                &plan.jobs[0].steps[2],
+                WorkflowStep::While { max_turns: 3, .. }
+            ));
+            assert_eq!(
+                plan.jobs[0].steps[3],
+                WorkflowStep::Label("done".to_string())
+            );
+            assert_eq!(
+                plan.jobs[0].steps[4],
+                WorkflowStep::Goto("done".to_string())
+            );
+            assert_eq!(plan.jobs[0].functions["build_one"][1], WorkflowStep::Return);
+        }
+
+        #[test]
+        fn rejects_misplaced_break_return_and_jumps() {
+            let root = tempdir().expect("root");
+            let workspace = root.path().join("repo");
+            fs::create_dir(&workspace).expect("workspace");
+            let prefix = format!(
+                "orangu:\n  version: 1\n  jobs:\n    - job: repo\n      workspace: {workspace:?}\n  main:\n",
+                workspace = workspace.display().to_string(),
+            );
+            for (name, step, message) in [
+                (
+                    "break",
+                    "    - break: true\n",
+                    "break outside a for or while loop",
+                ),
+                (
+                    "return",
+                    "    - return: true\n",
+                    "return outside a function",
+                ),
+                ("goto", "    - goto: nowhere\n", "unknown label 'nowhere'"),
+                (
+                    "for",
+                    "    - for:\n        var: x\n        do:\n          - command: /status\n",
+                    "for needs items or range",
+                ),
+                (
+                    "while",
+                    "    - while:\n        condition: /status\n        max_turns: 0\n        do:\n          - command: /status\n",
+                    "max_turns must be between 1",
+                ),
+            ] {
+                let yaml = format!("{prefix}{step}");
+                let error = compile(&yaml, root.path()).expect_err(name);
+                assert!(error.to_string().contains(message), "{name}: {error}");
+            }
+        }
+
+        #[test]
+        fn rejects_shadowed_loop_variables_and_cross_scope_jumps() {
+            let root = tempdir().expect("root");
+            let workspace = root.path().join("repo");
+            fs::create_dir(&workspace).expect("workspace");
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  jobs:
+    - job: repo
+      workspace: {workspace:?}
+  functions:
+    helper:
+      - label: inner
+      - command: /status
+  main:
+    - for:
+        var: x
+        items: [a]
+        do:
+          - for:
+              var: x
+              items: [b]
+              do:
+                - command: /status
+    - goto: inner
+"#,
+                workspace = workspace.display().to_string(),
+            );
+            let message = compile(&yaml, root.path())
+                .expect_err("shadowing and cross-scope goto")
+                .to_string();
+            assert!(
+                message.contains("shadows the outer for variable 'x'"),
+                "{message}"
+            );
+            assert!(message.contains("unknown label 'inner'"), "{message}");
+        }
+
+        #[test]
+        fn approvals_flow_through_calls_in_execution_order() {
+            let root = tempdir().expect("root");
+            let workspace = root.path().join("repo");
+            let external = root.path().join("output");
+            fs::create_dir(&workspace).expect("workspace");
+            fs::create_dir(&external).expect("external output");
+            // An approval authorizes later uses wherever the run reaches them:
+            // inside a called function, or after it returns.
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  variables:
+    output: {external:?}
+  jobs:
+    - job: repo
+      workspace: {workspace:?}
+  functions:
+    use_output:
+      - command: /shell ls ${{output}}/
+  main:
+    - approved: ${{output}}
+    - call: use_output
+    - command: /shell ls ${{output}}/
+"#,
+                external = external.display().to_string(),
+                workspace = workspace.display().to_string(),
+            );
+            let plan = compile(&yaml, root.path()).expect("approvals flow through calls");
+            assert_eq!(plan.jobs[0].steps.len(), 3);
+        }
+
+        #[test]
+        fn rejects_invalid_loop_duration_before_execution() {
+            let root = tempdir().expect("root");
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  jobs:
+    - job: repo
+      workspace: {workspace:?}
+  main:
+    - loop:
+        objective: Fix parser
+        stop:
+          type: time
+          duration: 10weeks
+"#,
+                workspace = root.path().display().to_string(),
+            );
+            let message = compile(&yaml, root.path())
+                .expect_err("invalid duration")
+                .to_string();
+            assert!(message.contains("invalid loop duration unit"));
+        }
+
+        #[test]
+        fn loop_checks_obey_external_path_approval_order() {
+            let root = tempdir().expect("root");
+            let workspace = root.path().join("repo");
+            let external = root.path().join("reports");
+            fs::create_dir(&workspace).expect("workspace");
+            fs::create_dir(&external).expect("reports");
+            let yaml = format!(
+                r#"orangu:
+  version: 1
+  variables:
+    reports: {external:?}
+  jobs:
+    - job: repo
+      workspace: {workspace:?}
+  main:
+    - loop:
+        objective: Fix parser
+        stop:
+          type: turns
+          count: 1
+        review:
+          checks:
+            - cp report.txt ${{reports}}/
+"#,
+                external = external.display().to_string(),
+                workspace = workspace.display().to_string(),
+            );
+            let message = compile(&yaml, root.path())
+                .expect_err("unapproved loop check")
+                .to_string();
+            assert!(message.contains("variable 'reports' outside the workspace"));
+
+            let approved = yaml.replace("  main:\n", "  main:\n    - approved: ${reports}\n");
+            compile(&approved, root.path()).expect("approval precedes loop check");
+        }
+    }
+}
+
+pub(crate) use language::{WorkflowLoop, WorkflowLoopStop, WorkflowPlan, WorkflowStep, compile};

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -961,6 +961,30 @@ pub fn resolve_workspace_path(workspace: &Path, raw_path: &str) -> Result<PathBu
     if !normalized.starts_with(&normalized_workspace) {
         return Err(anyhow!("path escapes the configured workspace"));
     }
+
+    // The lexical comparison above catches `..`, but an in-workspace symlink
+    // can still point outside. Canonicalize the nearest existing ancestor so
+    // this also protects paths for files that have not been created yet.
+    let canonical_workspace = normalized_workspace
+        .canonicalize()
+        .map_err(|error| anyhow!("failed to resolve configured workspace: {error}"))?;
+    let mut existing = normalized.as_path();
+    let anchor = loop {
+        if existing.exists() {
+            break existing;
+        }
+        existing = existing
+            .parent()
+            .ok_or_else(|| anyhow!("path has no existing parent inside the workspace"))?;
+    };
+    let canonical_anchor = anchor
+        .canonicalize()
+        .map_err(|error| anyhow!("failed to resolve workspace path: {error}"))?;
+    if !canonical_anchor.starts_with(&canonical_workspace) {
+        return Err(anyhow!(
+            "path escapes the configured workspace through a symlink"
+        ));
+    }
     Ok(normalized)
 }
 
@@ -1339,6 +1363,19 @@ mod tests {
         let workspace = PathBuf::from("/tmp/workspace");
         let err = resolve_workspace_path(&workspace, "../outside").unwrap_err();
         assert!(err.to_string().contains("escapes"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_escape() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let outside = tempfile::tempdir().expect("outside");
+        std::os::unix::fs::symlink(outside.path(), workspace.path().join("escape"))
+            .expect("symlink");
+
+        let err = resolve_workspace_path(workspace.path(), "escape/new.txt")
+            .expect_err("symlink must not leave workspace");
+        assert!(err.to_string().contains("symlink"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a validated YAML workflow language as a thin layer over Orangu commands, natural-language prompts, skills, and tools.

- Defines versioned workflows with global and per-job variables, job workspaces, roles, reusable functions, ordered main steps, explicit external-path approvals, and code-and-review loops.
- Validates and expands the complete workflow before starting any potentially long-running job.
- Adds --check-workflow for offline preflight and --workflow for sequential execution with one shared prompt conversation per job.
- Preflights explicit slash commands in every job, including required arguments, headless compatibility, and skills discovered separately in each workspace; all command errors are reported together.
- Routes workflow roles through configured servers or the coordinator and keeps every job inside its workspace policy.
- Folds in the complete bounded-loop implementation from #231: turn, time, and reviewer-verified goal policies; checks and review rubrics; feedback carry-over; diff evidence; bounded review input; persistence; status, pause, resume, clear, quiet mode, and per-workspace locking.
- Retains the standalone orangu loop CLI and reusable loop-file format while also exposing the same engine as a workflow loop step.
- Documents workflows and loops in the manual and cheat sheet and updates bash, zsh, and fish completions.

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- 515 library tests passed
- 520 client tests passed, including an end-to-end work then read-only review loop against a fake server
- Bench and coordinator test suites passed
- Manual and cheat-sheet PDFs build successfully

The local full-server suite also reaches hardware-only OpenCL/Vulkan tests; those fail on this machine during GPU backend initialization and are unrelated to this change.
